### PR TITLE
Correct export_csv blurb to match readme

### DIFF
--- a/nginx/templates/index.html
+++ b/nginx/templates/index.html
@@ -185,7 +185,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
         <div class="col-sm-6">
           <p>
-            Explore the "autompg" data set by selecting and highlighting different dimensions
+            Query a data table and save the results to a CSV file
           </p>
           <p>
             <em>Source code: </em><a target="_blank" href="https://github.com/bokeh/bokeh/blob/master/examples/app/export_csv">export_csv</a>


### PR DESCRIPTION
The [website](http://bokeh.pydata.org/en/latest/docs/gallery.html) displays this: 

![image](https://cloud.githubusercontent.com/assets/8301092/20467168/601870f8-af4f-11e6-8b8e-f9dce9346617.png)


The [readme's](https://github.com/bokeh/bokeh/blob/9650b109b62d385d372eecc1f9d5a511bf4a3d49/examples/app/README.md) description looked more accurate:

![image](https://cloud.githubusercontent.com/assets/8301092/20467162/55e998dc-af4f-11e6-80a9-921f340a6215.png)
