### PR TITLE
Reduce demo interaction latency and add performance telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,15 @@ push it to ECR under an immutable `sha-*` tag, register a new ECS task
 definition, update the `worker` service, wait for stability, and verify the
 production health endpoint.
 
+Pull requests run all checks and build the container without publishing or
+deploying it. Merging to `main` is therefore the normal release action; no
+Terraform command is needed for an application-only change. The workflow
+summary records the immutable image digest used by ECS.
+
 To roll back an application release, rerun the workflow for the desired commit
 or revert the change on `main`. ECR retains the twenty most recent immutable
 release images. Infrastructure operations are documented in the `bokeh/infra`
 AWS demo stack README.
+
+See [Production operations](docs/operations.md) for rollout verification,
+CloudWatch callback timings, event-loop lag queries, and smoke-test guidance.

--- a/apps/_common/__init__.py
+++ b/apps/_common/__init__.py
@@ -24,6 +24,8 @@ from catalog import DEMOS
 from presentation import SITE, configure_document
 
 from . import colors
+from .performance import monitor_document
+from .streaming import PeriodicCoalescer as PeriodicCoalescer
 
 REMOVE_LOADING_JS = (SITE / "remove_loading.js").read_text()
 ASSETS = Path(__file__).parent
@@ -59,6 +61,7 @@ def prepare_document(document, route: str) -> None:
     document.theme = "light_minimal"
     for root in document.roots:
         match_background(root, colors.PAPER)
+    monitor_document(document, route).start(document)
 
 
 def match_background(model, background: str) -> None:

--- a/apps/_common/performance.py
+++ b/apps/_common/performance.py
@@ -1,0 +1,161 @@
+"""Measure per-session callback time and event-loop lag for demo applications."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from functools import wraps
+from math import ceil
+from time import perf_counter
+from typing import Any, ParamSpec, TypeVar
+from weakref import WeakKeyDictionary
+
+from bokeh.document import Document
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+LOGGER = logging.getLogger("demo.performance")
+if not LOGGER.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    LOGGER.addHandler(handler)
+LOGGER.propagate = False
+LOGGER.setLevel(logging.INFO)
+
+PERFORMANCE_ENABLED = os.getenv("DEMO_PERFORMANCE", "1").casefold() not in {"0", "false", "no"}
+LOOP_INTERVAL_SECONDS = 1.0
+REPORT_INTERVAL_SECONDS = 60.0
+RECENT_SAMPLE_LIMIT = 256
+LAG_REPORT_THRESHOLD_MS = 20.0
+
+
+@dataclass(slots=True)
+class Samples:
+    """Accumulate bounded timing statistics for one reporting window."""
+
+    count: int = 0
+    total_ms: float = 0.0
+    maximum_ms: float = 0.0
+    recent_ms: deque[float] = field(default_factory=lambda: deque(maxlen=RECENT_SAMPLE_LIMIT))
+
+    def add(self, elapsed_ms: float) -> None:
+        """Record one duration in milliseconds."""
+        self.count += 1
+        self.total_ms += elapsed_ms
+        self.maximum_ms = max(self.maximum_ms, elapsed_ms)
+        self.recent_ms.append(elapsed_ms)
+
+    def summary(self) -> dict[str, int | float]:
+        """Return count, mean, p95, and maximum duration values."""
+        ordered = sorted(self.recent_ms)
+        p95_index = max(0, ceil(0.95 * len(ordered)) - 1)
+        return {
+            "count": self.count,
+            "mean_ms": round(self.total_ms / self.count, 3),
+            "p95_ms": round(ordered[p95_index], 3),
+            "max_ms": round(self.maximum_ms, 3),
+        }
+
+
+class PerformanceMonitor:
+    """Collect callback and event-loop timing for one Bokeh document."""
+
+    def __init__(self, route: str, *, enabled: bool = PERFORMANCE_ENABLED) -> None:
+        self.route = route
+        self.enabled = enabled
+        self.callbacks: dict[str, Samples] = {}
+        self.event_loop_lag = Samples()
+        self.started = False
+        self.last_loop_time = 0.0
+        self.last_report_time = 0.0
+
+    def measure(self, callback: Callable[P, R], *, name: str | None = None) -> Callable[P, R]:
+        """Wrap a Python callback and aggregate its execution duration."""
+        if not self.enabled:
+            return callback
+        callback_name = name or callback.__name__
+
+        @wraps(callback)
+        def timed_callback(*args: P.args, **kwargs: P.kwargs) -> R:
+            started = perf_counter()
+            try:
+                return callback(*args, **kwargs)
+            finally:
+                elapsed_ms = 1000 * (perf_counter() - started)
+                self.callbacks.setdefault(callback_name, Samples()).add(elapsed_ms)
+
+        return timed_callback
+
+    def start(self, document: Document) -> None:
+        """Begin periodic lag sampling after the application is assembled."""
+        if self.started or not self.enabled:
+            return
+        self.started = True
+        now = perf_counter()
+        self.last_loop_time = now
+        self.last_report_time = now
+        document.add_periodic_callback(self.observe_event_loop, int(1000 * LOOP_INTERVAL_SECONDS))
+
+        def session_destroyed(_session_context: Any) -> None:
+            self.report(force=True)
+
+        document.on_session_destroyed(session_destroyed)
+
+    def observe_event_loop(self) -> None:
+        """Sample scheduling delay and emit summaries at the reporting interval."""
+        now = perf_counter()
+        elapsed = now - self.last_loop_time
+        self.last_loop_time = now
+        self.event_loop_lag.add(1000 * max(0.0, elapsed - LOOP_INTERVAL_SECONDS))
+        self.report(now=now)
+
+    def report(self, *, now: float | None = None, force: bool = False) -> None:
+        """Write structured summaries suitable for CloudWatch Logs Insights."""
+        current = perf_counter() if now is None else now
+        if not force and current - self.last_report_time < REPORT_INTERVAL_SECONDS:
+            return
+        window_seconds = round(current - self.last_report_time, 3)
+        self.last_report_time = current
+        callback_activity = False
+        for callback_name, samples in self.callbacks.items():
+            if samples.count:
+                callback_activity = True
+                self.log_summary("demo.callback", samples, window_seconds, callback=callback_name)
+        if self.event_loop_lag.count and (
+            callback_activity or self.event_loop_lag.maximum_ms >= LAG_REPORT_THRESHOLD_MS
+        ):
+            self.log_summary("demo.event_loop_lag", self.event_loop_lag, window_seconds)
+        self.callbacks.clear()
+        self.event_loop_lag = Samples()
+
+    def log_summary(
+        self, event: str, samples: Samples, window_seconds: float, **fields: str
+    ) -> None:
+        """Emit one compact JSON timing summary."""
+        payload = {
+            "event": event,
+            "app": self.route,
+            "window_seconds": window_seconds,
+            **fields,
+            **samples.summary(),
+        }
+        LOGGER.info(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+
+
+MONITORS: WeakKeyDictionary[Document, PerformanceMonitor] = WeakKeyDictionary()
+
+
+def monitor_document(document: Document, route: str) -> PerformanceMonitor:
+    """Return the performance monitor associated with a Bokeh document."""
+    monitor = MONITORS.get(document)
+    if monitor is None:
+        monitor = PerformanceMonitor(route)
+        MONITORS[document] = monitor
+    elif monitor.route != route:
+        raise ValueError(f"Document already belongs to {monitor.route}, not {route}")
+    return monitor

--- a/apps/_common/streaming.py
+++ b/apps/_common/streaming.py
@@ -1,0 +1,30 @@
+"""Helpers for bounded real-time simulation updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+
+
+@dataclass(slots=True)
+class PeriodicCoalescer:
+    """Convert delayed periodic callbacks into one bounded batch of simulation ticks."""
+
+    interval_seconds: float
+    max_ticks: int = 4
+    last_call: float | None = None
+
+    def due_ticks(self, *, now: float | None = None) -> int:
+        """Return elapsed ticks while dropping excess backlog after a long stall."""
+        current = perf_counter() if now is None else now
+        if self.last_call is None:
+            self.last_call = current
+            return 1
+        elapsed = max(0.0, current - self.last_call)
+        self.last_call = current
+        ticks = max(1, int(elapsed / self.interval_seconds + 0.5))
+        return min(ticks, self.max_ticks)
+
+    def reset(self, *, now: float | None = None) -> None:
+        """Reset elapsed-time accounting after a simulation restart or pause."""
+        self.last_call = perf_counter() if now is None else now

--- a/apps/airport_map.py
+++ b/apps/airport_map.py
@@ -28,6 +28,7 @@ from apps._common import (
     match_background,
     metric,
     metric_row,
+    monitor_document,
     prepare_document,
     responsive_row,
     set_metric,
@@ -82,6 +83,7 @@ def distance_miles(
 
 
 def modify_document(document) -> None:
+    performance = monitor_document(document, "/airport-access")
     airports = cast(pd.DataFrame, local_data.airports()).dropna().copy()
     airports = cast(pd.DataFrame, airports[airports["state"].isin(STATE_NAMES)])
     airports = airports.sort_values(by=["state", "city", "name"]).reset_index(drop=True)
@@ -107,7 +109,10 @@ def modify_document(document) -> None:
     )
     anchor = Select(title="Anchor airport", value="SEA", options=[])
 
-    airport_source = ColumnDataSource(data={}, name="airport-map")
+    airport_source = ColumnDataSource(
+        data={**airport_data, "distance": np.zeros(len(airports), dtype=np.float32)},
+        name="airport-map",
+    )
     viewport_source = ColumnDataSource(data={"x": [], "y": []}, name="airport-map-viewport")
     anchor_source = ColumnDataSource(data={"x": [], "y": [], "iata": []}, name="airport-anchor")
     route_source = ColumnDataSource(data={"xs": [], "ys": []}, name="airport-routes")
@@ -246,7 +251,7 @@ def modify_document(document) -> None:
             airport_latitudes,
             airport_longitudes,
         )
-        airport_source.data = dict(airport_data, distance=distances)
+        airport_source.patch({"distance": [(slice(len(distances)), distances.astype(np.float32))]})
         airport_source.selected.indices = [selected_index]
         anchor_source.data = {
             "x": [selected["x"]],
@@ -349,9 +354,9 @@ def modify_document(document) -> None:
                 anchor.options = [(selected_iata, label), *options]
             anchor.value = selected_iata
 
-    state.on_change("value", choose_state)
-    anchor.on_change("value", choose_airport)
-    airport_source.selected.on_change("indices", tap_airport)
+    state.on_change("value", performance.measure(choose_state))
+    anchor.on_change("value", performance.measure(choose_airport))
+    airport_source.selected.on_change("indices", performance.measure(tap_airport))
     update_state()
 
     introduction = Div(

--- a/apps/cellular_automata/__init__.py
+++ b/apps/cellular_automata/__init__.py
@@ -24,7 +24,14 @@ from bokeh.models import (
 )
 from bokeh.plotting import figure
 
-from apps._common import match_background, prepare_document, responsive_row, style_figure, wrap_row
+from apps._common import (
+    match_background,
+    monitor_document,
+    prepare_document,
+    responsive_row,
+    style_figure,
+    wrap_row,
+)
 from apps._common.colors import CORAL, GOLD, GRID, INK, MUTED, PAPER, TEAL, WARM
 from apps.cellular_automata.model import (
     BRUSHES,
@@ -71,6 +78,7 @@ COMPARISON_PALETTE = (BACKGROUND, COMPARISON_A, COMPARISON_B, COMPARISON_SHARED)
 
 
 def modify_document(document) -> None:
+    performance = monitor_document(document, "/cellular-automata")
     experiment = Select(
         title="Experiment", value="Single rule", options=["Single rule", "Compare rules"]
     )
@@ -133,7 +141,9 @@ def modify_document(document) -> None:
         )
     )
 
-    image_source = ColumnDataSource(data={"image": []}, name="automata-field")
+    image_source = ColumnDataSource(
+        data={"image": [np.zeros((ROWS, COLUMNS), dtype=np.uint16)]}, name="automata-field"
+    )
     history_source = ColumnDataSource(
         data={
             "generation": [],
@@ -375,9 +385,9 @@ def modify_document(document) -> None:
             comparison_image[state.field & ~state.comparison_field] = 1
             comparison_image[~state.field & state.comparison_field] = 2
             comparison_image[state.field & state.comparison_field] = 3
-            image_source.data = {"image": [comparison_image]}
+            image_source.patch({"image": [(0, comparison_image)]})
         else:
-            image_source.data = {"image": [state.age]}
+            image_source.patch({"image": [(0, state.age)]})
         update_status()
 
     def reset_history() -> None:
@@ -472,21 +482,18 @@ def modify_document(document) -> None:
             playing.button_type = "default"
 
     def update_latest_history() -> None:
-        data = history_source.data
-        history_source.data = {
-            "generation": [*data["generation"]],
-            "population": [*data["population"][:-1], int(state.field.sum())],
-            "comparison_population": [
-                *data["comparison_population"][:-1],
-                int(state.comparison_field.sum()),
-            ],
-            "divergence": [
-                *data["divergence"][:-1],
-                int(np.count_nonzero(state.field != state.comparison_field)),
-            ],
-            "births": [*data["births"][:-1], 0],
-            "deaths": [*data["deaths"][:-1], 0],
-        }
+        last = len(history_source.data["generation"]) - 1
+        history_source.patch(
+            {
+                "population": [(last, int(state.field.sum()))],
+                "comparison_population": [(last, int(state.comparison_field.sum()))],
+                "divergence": [
+                    (last, int(np.count_nonzero(state.field != state.comparison_field)))
+                ],
+                "births": [(last, 0)],
+                "deaths": [(last, 0)],
+            }
+        )
 
     def edit_field(event: Event) -> None:
         if not isinstance(event, Tap) or event.x is None or event.y is None:
@@ -665,30 +672,30 @@ def modify_document(document) -> None:
         state.brush_flipped = not state.brush_flipped
         flip_pattern.label = f"Mirror · {'on' if state.brush_flipped else 'off'}"
 
-    experiment.on_change("value", experiment_changed)
-    seed.on_change("value", seed_changed)
-    rule.on_change("value", rule_changed)
-    comparison_rule.on_change("value", comparison_rule_changed)
-    primary_birth.on_change("value", primary_custom_rule_changed)
-    primary_survival.on_change("value", primary_custom_rule_changed)
-    comparison_birth.on_change("value", comparison_custom_rule_changed)
-    comparison_survival.on_change("value", comparison_custom_rule_changed)
-    brush.on_change("value", brush_changed)
-    density.on_change("value_throttled", density_changed)
-    playing.on_click(toggle_playing)
-    wrap_edges.on_click(toggle_wrap)
-    rotate_pattern.on_click(rotate_brush)
-    flip_pattern.on_click(flip_brush)
-    restart.on_click(load_seed)
-    step.on_click(lambda: advance(force=True))
-    clear.on_click(clear_field)
-    field_plot.on_event(Tap, edit_field)
+    experiment.on_change("value", performance.measure(experiment_changed))
+    seed.on_change("value", performance.measure(seed_changed))
+    rule.on_change("value", performance.measure(rule_changed))
+    comparison_rule.on_change("value", performance.measure(comparison_rule_changed))
+    primary_birth.on_change("value", performance.measure(primary_custom_rule_changed))
+    primary_survival.on_change("value", performance.measure(primary_custom_rule_changed))
+    comparison_birth.on_change("value", performance.measure(comparison_custom_rule_changed))
+    comparison_survival.on_change("value", performance.measure(comparison_custom_rule_changed))
+    brush.on_change("value", performance.measure(brush_changed))
+    density.on_change("value_throttled", performance.measure(density_changed))
+    playing.on_click(performance.measure(toggle_playing))
+    wrap_edges.on_click(performance.measure(toggle_wrap))
+    rotate_pattern.on_click(performance.measure(rotate_brush))
+    flip_pattern.on_click(performance.measure(flip_brush))
+    restart.on_click(performance.measure(load_seed))
+    step.on_click(performance.measure(lambda: advance(force=True), name="step_once"))
+    clear.on_click(performance.measure(clear_field))
+    field_plot.on_event(Tap, performance.measure(edit_field))
 
     update_notes()
     update_brush_note()
     load_seed()
     update_visual_mode()
-    document.add_periodic_callback(advance, 100)
+    document.add_periodic_callback(performance.measure(advance), 100)
 
     controls = column(
         Div(

--- a/apps/climate.py
+++ b/apps/climate.py
@@ -29,6 +29,7 @@ from apps._common import (
     match_background,
     metric,
     metric_row,
+    monitor_document,
     prepare_document,
     responsive_row,
     set_metric,
@@ -42,6 +43,7 @@ RAIN_PALETTE = ["#f7f3ec", "#d8d2bd", "#a9b9aa", "#6d9792", "#4f7b7c", "#2a1723"
 
 
 def modify_document(document) -> None:
+    performance = monitor_document(document, "/climate")
     frame = cast(pd.DataFrame, local_data.seattle_weather()).copy()
     frame["year"] = frame["date"].dt.year
     frame["day"] = [date.replace(year=2000).dayofyear for date in frame["date"]]
@@ -344,13 +346,17 @@ def modify_document(document) -> None:
         }
 
         outlines = [CORAL if value == year.value else PAPER for value in monthly["year_name"]]
-        monthly_source.data = {
-            **monthly_source.data,
-            "outline": outlines,
-            "outline_width": [
-                1.5 if value == year.value else 0.75 for value in monthly["year_name"]
-            ],
-        }
+        monthly_source.patch(
+            {
+                "outline": [(slice(len(outlines)), outlines)],
+                "outline_width": [
+                    (
+                        slice(len(outlines)),
+                        [1.5 if value == year.value else 0.75 for value in monthly["year_name"]],
+                    )
+                ],
+            }
+        )
 
         total_rain = float(selected["precipitation"].sum())
         rain_delta = total_rain / float(annual_rain.mean()) - 1
@@ -382,9 +388,9 @@ def modify_document(document) -> None:
     def update(_attr: str, _old: object, _new: object) -> None:
         calculate()
 
-    year.on_change("value", update)
-    smoothing.on_change("value", update)
-    heavy_rain.on_change("value", update)
+    year.on_change("value", performance.measure(update))
+    smoothing.on_change("value_throttled", performance.measure(update))
+    heavy_rain.on_change("value_throttled", performance.measure(update))
     calculate()
 
     attribution = Div(

--- a/apps/heatmap.py
+++ b/apps/heatmap.py
@@ -7,6 +7,7 @@ from bokeh.layouts import column
 from bokeh.models import (
     ColorBar,
     ColumnDataSource,
+    CustomJS,
     Div,
     LinearColorMapper,
     Range1d,
@@ -22,6 +23,7 @@ from apps._common import (
     match_background,
     metric,
     metric_row,
+    monitor_document,
     prepare_document,
     responsive_row,
     set_metric,
@@ -122,6 +124,7 @@ def evaluate_field(
 
 
 def modify_document(document) -> None:
+    performance = monitor_document(document, "/wave-field")
     xx, yy = np.meshgrid(FIELD_AXIS, FIELD_AXIS)
     field_source = ColumnDataSource(
         data={"x": xx.ravel(), "y": yy.ravel(), "z": np.zeros(xx.size)}, name="wave-field-values"
@@ -162,7 +165,15 @@ def modify_document(document) -> None:
         fill_color={"field": "z", "transform": mapper},
     )
     section_marker = Span(
-        location=0, dimension="width", line_color=GOLD, line_width=3, line_dash="dashed"
+        location=0,
+        dimension="width",
+        line_color=GOLD,
+        line_width=3,
+        line_dash="dashed",
+        syncable=False,
+    )
+    cross_section.js_on_change(
+        "value", CustomJS(args={"marker": section_marker}, code="marker.location = cb_obj.value")
     )
     field_plot.add_layout(section_marker)
     field_plot.add_layout(
@@ -200,34 +211,45 @@ def modify_document(document) -> None:
     distribution.yaxis.axis_label = "Cells"
     style_figure(distribution)
 
-    def calculate() -> None:
+    def update_section() -> None:
         f = frequency.value
         c = coupling.value
-        values = evaluate_field(field.value, xx, yy, f, c)
         section_y = float(cross_section.value)
         section = evaluate_field(
             field.value, SECTION_AXIS, np.full_like(SECTION_AXIS, section_y), f, c
         )
-        counts, edges = np.histogram(values, bins=24)
+        section_source.patch({"z": [(slice(SECTION_AXIS.size), section.astype(np.float32))]})
+        section_marker.location = section_y
+        set_metric(section_card, f"{np.mean(section):+.2f}")
 
+    def calculate_field() -> None:
+        values = evaluate_field(field.value, xx, yy, frequency.value, coupling.value)
+        counts, edges = np.histogram(values, bins=24)
         mapper.low = float(values.min())
         mapper.high = float(values.max())
-        mapper.palette = palettes[palette.value]
-        field_source.data = {"x": xx.ravel(), "y": yy.ravel(), "z": values.ravel()}
-        section_source.data = {"x": SECTION_AXIS, "z": section}
+        # Coordinates are immutable, so only send the computed value array.
+        field_source.patch({"z": [(slice(xx.size), values.ravel().astype(np.float32))]})
         distribution_source.data = {"top": counts, "left": edges[:-1], "right": edges[1:]}
-        section_marker.location = section_y
         set_metric(minimum_card, f"{values.min():.2f}")
         set_metric(maximum_card, f"{values.max():.2f}")
         set_metric(energy_card, f"{np.mean(values**2):.2f}")
-        set_metric(section_card, f"{np.mean(section):+.2f}")
+        update_section()
 
-    def update(_attr: str, _old: object, _new: object) -> None:
-        calculate()
+    def update_field(_attr: str, _old: object, _new: object) -> None:
+        calculate_field()
 
-    for control in (field, frequency, coupling, cross_section, palette):
-        control.on_change("value", update)
-    calculate()
+    def update_cross_section(_attr: str, _old: object, _new: object) -> None:
+        update_section()
+
+    def update_palette(_attr: str, _old: object, _new: object) -> None:
+        mapper.palette = palettes[palette.value]
+
+    field.on_change("value", performance.measure(update_field))
+    palette.on_change("value", performance.measure(update_palette))
+    frequency.on_change("value_throttled", performance.measure(update_field))
+    coupling.on_change("value_throttled", performance.measure(update_field))
+    cross_section.on_change("value_throttled", performance.measure(update_cross_section))
+    calculate_field()
 
     controls = column(
         Div(

--- a/apps/image_lab/__init__.py
+++ b/apps/image_lab/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from html import escape
 from time import perf_counter
+from typing import cast
 
 import numpy as np
 import xarray as xr
@@ -23,7 +24,14 @@ from bokeh.models import (
 from bokeh.plotting import figure
 from skimage import data
 
-from apps._common import load_javascript, prepare_document, responsive_row, style_figure, wrap_row
+from apps._common import (
+    load_javascript,
+    monitor_document,
+    prepare_document,
+    responsive_row,
+    style_figure,
+    wrap_row,
+)
 from apps._common.colors import CORAL, GOLD
 from apps.image_lab.processing import FILTERS
 
@@ -52,6 +60,7 @@ def rgba_view(image: np.ndarray) -> np.ndarray:
 
 
 def modify_document(document) -> None:
+    performance = monitor_document(document, "/image-processing")
     raw = data.hubble_deep_field()
     cube = xr.DataArray(
         raw,
@@ -70,11 +79,59 @@ def modify_document(document) -> None:
         image_filter.processor(sample, amount)
 
     operation = Select(title="Processing step", value="Sobel edges", options=list(FILTERS))
-    strength = Slider(title="Edge gain", start=0.5, end=5.0, value=2.2, step=0.1)
+    strength = Slider(title="Edge gain", start=0.5, end=5.0, value=2.2, step=0.1, syncable=False)
+    strength_request = ColumnDataSource(
+        data={"value": [strength.value]}, name="hubble-strength-request"
+    )
+    strength.js_on_change(
+        "value",
+        CustomJS(
+            args={"request": strength_request},
+            code="""
+                const throttle = cb_obj.tags[0] ?? {last_sent: 0, timeout: null}
+                const send_request = () => {
+                    const value = cb_obj.value
+                    if (request.data.value[0] != value) {
+                        request.data = {value: [value]}
+                        request.change.emit()
+                    }
+                    throttle.last_sent = Date.now()
+                    throttle.timeout = null
+                }
+                const remaining = 200 - (Date.now() - throttle.last_sent)
+                if (remaining <= 0) {
+                    clearTimeout(throttle.timeout)
+                    send_request()
+                } else {
+                    clearTimeout(throttle.timeout)
+                    throttle.timeout = setTimeout(send_request, remaining)
+                }
+                cb_obj.tags = [throttle]
+            """,
+        ),
+    )
+    strength.js_on_change(
+        "value_throttled",
+        CustomJS(
+            args={"request": strength_request},
+            code="""
+                const throttle = cb_obj.tags[0]
+                if (throttle != null) clearTimeout(throttle.timeout)
+                const value = cb_obj.value
+                if (request.data.value[0] != value) {
+                    request.data = {value: [value]}
+                    request.change.emit()
+                }
+                cb_obj.tags = [{last_sent: Date.now(), timeout: null}]
+            """,
+        ),
+    )
     reset_crop = Button(label="Reset crop", height=31, margin=(22, 0, 0, 0))
     crop = {"x": (260, 740), "y": (196, 676)}
     source_image = ColumnDataSource(data={"image": [rgba_view(raw)]})
-    processed_source = ColumnDataSource(data={"image": []}, name="hubble-processed-image")
+    processed_source = ColumnDataSource(
+        data={"image": [np.zeros((1, 1), dtype=np.uint32)]}, name="hubble-processed-image"
+    )
     initial_crop_box = {
         "left": 260 / raw.shape[1],
         "right": 740 / raw.shape[1],
@@ -95,7 +152,9 @@ def modify_document(document) -> None:
             initial_crop_box["top"],
         ],
     }
-    crop_handles = ColumnDataSource(data=dict(initial_crop_handles), name="hubble-crop-handles")
+    crop_handles = ColumnDataSource(
+        data=dict(initial_crop_handles), name="hubble-crop-handles", syncable=False
+    )
     crop_interaction = ColumnDataSource(
         data={
             "mode": [""],
@@ -105,7 +164,11 @@ def modify_document(document) -> None:
             "right": [initial_crop_box["right"]],
             "bottom": [initial_crop_box["bottom"]],
             "top": [initial_crop_box["top"]],
-        }
+        },
+        syncable=False,
+    )
+    crop_request = ColumnDataSource(
+        data={name: [value] for name, value in initial_crop_box.items()}, name="hubble-crop-request"
     )
     crop_pan = PanTool(dimensions="both")
     report = Div(
@@ -155,6 +218,7 @@ def modify_document(document) -> None:
         hover_fill_alpha=0.15,
         hover_line_color=GOLD,
         hover_line_width=3,
+        syncable=False,
     )
     original.add_layout(crop_box)
     original.scatter(
@@ -173,11 +237,17 @@ def modify_document(document) -> None:
         code=load_javascript(__file__, "start_crop.js"),
     )
     update_crop_box = CustomJS(
-        args={"box": crop_box, "handles": crop_handles, "state": crop_interaction},
+        args={
+            "box": crop_box,
+            "handles": crop_handles,
+            "request": crop_request,
+            "state": crop_interaction,
+        },
         code=load_javascript(__file__, "update_crop_box.js"),
     )
     end_crop = CustomJS(
-        args={"state": crop_interaction}, code=load_javascript(__file__, "end_crop.js")
+        args={"box": crop_box, "request": crop_request, "state": crop_interaction},
+        code=load_javascript(__file__, "end_crop.js"),
     )
     original.js_on_event(PanStart, start_crop)
     original.js_on_event(Pan, update_crop_box)
@@ -199,7 +269,6 @@ def modify_document(document) -> None:
     style_figure(processed)
 
     configuring = {"operation": False}
-    pending_crop_update = {"callback": None}
 
     def calculate() -> None:
         x_low, x_high = crop["x"]
@@ -213,7 +282,7 @@ def modify_document(document) -> None:
         result = image_filter.processor(image, strength.value)
         elapsed = 1000 * (perf_counter() - started)
         height, width, _ = image.shape
-        processed_source.data = {"image": [rgba_view(result)]}
+        processed_source.patch({"image": [(0, rgba_view(result))]})
         processed_title.text = image_heading("02", "Processed view", operation.value, CORAL)
         report.text = (
             f"<p><strong>{operation.value}</strong> applied &nbsp; <strong>{width} x {height}</strong> pixels &nbsp; "
@@ -222,18 +291,9 @@ def modify_document(document) -> None:
         )
 
     def apply_crop() -> None:
-        pending_crop_update["callback"] = None
-        bounds = (crop_box.left, crop_box.right, crop_box.bottom, crop_box.top)
-        left_value, right_value, bottom_value, top_value = bounds
-        if not (
-            isinstance(left_value, (int, float))
-            and isinstance(right_value, (int, float))
-            and isinstance(bottom_value, (int, float))
-            and isinstance(top_value, (int, float))
-        ):
-            return
-        left, right = sorted((float(left_value), float(right_value)))
-        bottom, top = sorted((float(bottom_value), float(top_value)))
+        bounds = cast(dict[str, list[float]], crop_request.data)
+        left, right = sorted((float(bounds["left"][0]), float(bounds["right"][0])))
+        bottom, top = sorted((float(bounds["bottom"][0]), float(bounds["top"][0])))
         x_low = int(np.clip(left * raw.shape[1], 0, raw.shape[1] - 1))
         x_high = int(np.clip(right * raw.shape[1], x_low + 1, raw.shape[1]))
         y_low = int(np.clip((1 - top) * raw.shape[0], 0, raw.shape[0] - 1))
@@ -243,19 +303,14 @@ def modify_document(document) -> None:
         calculate()
 
     def update_crop(_attr: str, _old: object, _new: object) -> None:
-        callback = pending_crop_update["callback"]
-        if callback is not None:
-            document.remove_timeout_callback(callback)
-        if document.session_context is None:
-            apply_crop()
-        else:
-            pending_crop_update["callback"] = document.add_timeout_callback(apply_crop, 80)
+        apply_crop()
 
     def restore_crop() -> None:
         crop["x"] = (260, 740)
         crop["y"] = (196, 676)
         crop_box.update(**initial_crop_box)
         crop_handles.data = dict(initial_crop_handles)
+        crop_request.data = {name: [value] for name, value in initial_crop_box.items()}
 
     def configure_filter(_attr: str, _old: object, _new: object) -> None:
         image_filter = FILTERS[operation.value]
@@ -266,6 +321,7 @@ def modify_document(document) -> None:
             strength.end = slider.end
             strength.step = slider.step
             strength.value = slider.value
+            strength_request.data = {"value": [slider.value]}
             strength.title = slider.title
         strength.disabled = slider is None
         strength.visible = slider is not None
@@ -275,13 +331,13 @@ def modify_document(document) -> None:
 
     def update_strength(_attr: str, _old: object, _new: object) -> None:
         if not configuring["operation"]:
+            strength.value = float(cast(float, strength_request.data["value"][0]))
             calculate()
 
-    operation.on_change("value", configure_filter)
-    strength.on_change("value", update_strength)
-    reset_crop.on_click(restore_crop)
-    for property_name in ("left", "right", "bottom", "top"):
-        crop_box.on_change(property_name, update_crop)
+    operation.on_change("value", performance.measure(configure_filter))
+    strength_request.on_change("data", performance.measure(update_strength))
+    reset_crop.on_click(performance.measure(restore_crop))
+    crop_request.on_change("data", performance.measure(update_crop))
     configure_filter("value", None, operation.value)
 
     intro = Div(
@@ -297,7 +353,7 @@ def modify_document(document) -> None:
         text=(
             "<p><strong>Move:</strong> drag anywhere inside the shaded crop. "
             "<strong>Resize:</strong> drag any gold corner. "
-            "The processed image updates after each adjustment.</p>"
+            "The processed image updates at a measured pace while you drag.</p>"
         ),
         styles={
             "padding": "10px 14px",

--- a/apps/image_lab/end_crop.js
+++ b/apps/image_lab/end_crop.js
@@ -1,2 +1,10 @@
+request.data = {
+  left: [box.left],
+  right: [box.right],
+  bottom: [box.bottom],
+  top: [box.top],
+}
+request.change.emit()
+state.tags = [Date.now()]
 state.data.mode[0] = ""
 state.change.emit()

--- a/apps/image_lab/update_crop_box.js
+++ b/apps/image_lab/update_crop_box.js
@@ -32,3 +32,12 @@ handles.data = {
   y: [bottom, bottom, top, top],
 }
 handles.change.emit()
+
+// Preserve smooth browser-side motion while limiting expensive Python image work.
+const now = Date.now()
+const last_sent = state.tags[0] ?? 0
+if (now - last_sent >= 200) {
+  request.data = {left: [left], right: [right], bottom: [bottom], top: [top]}
+  request.change.emit()
+  state.tags = [now]
+}

--- a/apps/market_monitor.py
+++ b/apps/market_monitor.py
@@ -23,9 +23,11 @@ from bokeh.models import (
 from bokeh.plotting import figure
 
 from apps._common import (
+    PeriodicCoalescer,
     match_background,
     metric,
     metric_row,
+    monitor_document,
     prepare_document,
     responsive_row,
     set_metric,
@@ -40,6 +42,9 @@ BARS_PER_SESSION = 390 // BAR_MINUTES
 SEED_BARS = 64
 WINDOW_BARS = 64
 BAR_WIDTH = 0.8
+FAST_ALPHA = 2 / 13
+SLOW_ALPHA = 2 / 27
+SIGNAL_ALPHA = 2 / 10
 UPDATE_TICKS = {"Slow": 6, "Medium": 3, "Fast": 1}
 REGIMES = {
     "Steady growth": {"drift": 0.010, "reversion": 0.010, "volume": 2.8, "volatility": 0.65},
@@ -54,6 +59,8 @@ REGIME_DESCRIPTIONS = {
 
 
 def modify_document(document) -> None:
+    performance = monitor_document(document, "/market-monitor")
+    coalescer = PeriodicCoalescer(0.15)
     regime = Select(title="Market regime", value="Steady growth", options=list(REGIMES))
     regime_note = Div(
         name="market-regime-note",
@@ -274,25 +281,51 @@ def modify_document(document) -> None:
             "color": [color],
         }
 
-    def update_summary() -> None:
+    def reset_indicators() -> None:
         shown = cast(pd.DataFrame, pd.DataFrame(price_source.data))
-        latest = shown.iloc[-1]
-        previous = shown.iloc[-2]
-        returns = shown["close"].pct_change().dropna().tail(20)
         fast_average = shown["close"].ewm(span=12, adjust=False).mean()
         slow_average = shown["close"].ewm(span=26, adjust=False).mean()
         macd_values = fast_average - slow_average
         signal_values = macd_values.ewm(span=9, adjust=False).mean()
         indicator_source.data = {
-            "index": shown["index"].to_list(),
+            "index": shown["index"].to_numpy(dtype=np.int32),
             "date": shown["date"].to_list(),
-            "macd": macd_values.to_list(),
-            "signal": signal_values.to_list(),
-            "positive_macd": np.maximum(macd_values, signal_values).to_list(),
-            "positive_signal": signal_values.to_list(),
-            "negative_macd": np.minimum(macd_values, signal_values).to_list(),
-            "negative_signal": signal_values.to_list(),
+            "macd": macd_values.to_numpy(dtype=np.float32),
+            "signal": signal_values.to_numpy(dtype=np.float32),
+            "positive_macd": np.maximum(macd_values, signal_values).to_numpy(dtype=np.float32),
+            "positive_signal": signal_values.to_numpy(dtype=np.float32),
+            "negative_macd": np.minimum(macd_values, signal_values).to_numpy(dtype=np.float32),
+            "negative_signal": signal_values.to_numpy(dtype=np.float32),
         }
+        state["fast_ema"] = float(fast_average.iloc[-1])
+        state["slow_ema"] = float(slow_average.iloc[-1])
+        state["signal_ema"] = float(signal_values.iloc[-1])
+
+    def append_indicators(candles: dict[str, list[Any]]) -> None:
+        values = {name: [] for name in indicator_source.data}
+        for index, date, close in zip(
+            candles["index"], candles["date"], candles["close"], strict=True
+        ):
+            fast = FAST_ALPHA * close + (1 - FAST_ALPHA) * state["fast_ema"]
+            slow = SLOW_ALPHA * close + (1 - SLOW_ALPHA) * state["slow_ema"]
+            macd_value = fast - slow
+            signal_value = SIGNAL_ALPHA * macd_value + (1 - SIGNAL_ALPHA) * state["signal_ema"]
+            state.update(fast_ema=fast, slow_ema=slow, signal_ema=signal_value)
+            values["index"].append(index)
+            values["date"].append(date)
+            values["macd"].append(macd_value)
+            values["signal"].append(signal_value)
+            values["positive_macd"].append(max(macd_value, signal_value))
+            values["positive_signal"].append(signal_value)
+            values["negative_macd"].append(min(macd_value, signal_value))
+            values["negative_signal"].append(signal_value)
+        indicator_source.stream(cast(Any, values), rollover=WINDOW_BARS)
+
+    def update_summary() -> None:
+        shown = cast(pd.DataFrame, pd.DataFrame(price_source.data))
+        latest = shown.iloc[-1]
+        previous = shown.iloc[-2]
+        returns = shown["close"].pct_change().dropna().tail(20)
         move = latest["close"] / previous["close"] - 1
         annualized = (
             float(returns.std() * np.sqrt(252 * BARS_PER_SESSION)) if len(returns) > 1 else 0.0
@@ -335,17 +368,26 @@ def modify_document(document) -> None:
             for name, values in candle.items():
                 columns[name].extend(values)
         price_source.data = cast(Any, columns)
+        reset_indicators()
         update_summary()
+        coalescer.reset()
 
     def advance(*, force: bool = False) -> None:
         if not playing.active and not force:
             return
-        if not force:
-            state["ticks"] = int(state["ticks"]) + 1
-            if int(state["ticks"]) < UPDATE_TICKS[speed.value]:
-                return
-            state["ticks"] = 0
-        price_source.stream(cast(Any, next_candle()), rollover=WINDOW_BARS)
+        if force:
+            updates = 1
+        else:
+            state["ticks"] = int(state["ticks"]) + coalescer.due_ticks()
+            updates, state["ticks"] = divmod(int(state["ticks"]), UPDATE_TICKS[speed.value])
+        if not updates:
+            return
+        candles: dict[str, list[Any]] = {name: [] for name in price_source.data}
+        for _ in range(updates):
+            for name, values in next_candle().items():
+                candles[name].extend(values)
+        price_source.stream(cast(Any, candles), rollover=WINDOW_BARS)
+        append_indicators(candles)
         update_summary()
 
     def regime_changed(_attr: str, _old: object, _new: object) -> None:
@@ -354,18 +396,20 @@ def modify_document(document) -> None:
 
     def playback_changed(_attr: str, _old: bool, active: bool) -> None:
         playing.label = "Pause simulation" if active else "Resume simulation"
+        if active:
+            coalescer.reset()
 
     def inject_selloff() -> None:
         state["shock"] = -0.08
         if not playing.active:
             advance(force=True)
 
-    regime.on_change("value", regime_changed)
-    playing.on_change("active", playback_changed)
-    selloff.on_click(inject_selloff)
-    restart.on_click(reset_simulation)
+    regime.on_change("value", performance.measure(regime_changed))
+    playing.on_change("active", performance.measure(playback_changed))
+    selloff.on_click(performance.measure(inject_selloff))
+    restart.on_click(performance.measure(reset_simulation))
     reset_simulation()
-    document.add_periodic_callback(advance, 150)
+    document.add_periodic_callback(performance.measure(advance), 150)
 
     key = Div(
         text=(

--- a/apps/mobility.py
+++ b/apps/mobility.py
@@ -15,6 +15,7 @@ from apps._common import (
     match_background,
     metric,
     metric_row,
+    monitor_document,
     prepare_document,
     responsive_row,
     set_metric,
@@ -24,6 +25,7 @@ from apps._common.colors import CORAL, GOLD, TEAL, VIOLET, WARM
 
 
 def modify_document(document) -> None:
+    performance = monitor_document(document, "/mobility")
     frame = cast(pd.DataFrame, local_data.cars()).dropna().copy()
     frame["Model_year"] = frame["Year"].dt.year
     colors = {"USA": CORAL, "Europe": TEAL, "Japan": VIOLET}
@@ -201,9 +203,10 @@ def modify_document(document) -> None:
     def update_selection(_attr: str, _old: list[int], indices: list[int]) -> None:
         update_analysis(np.asarray(indices, dtype=int))
 
-    for control in (origin_filter, year_filter, cylinder_filter, x_axis, y_axis):
-        control.on_change("value", update_filter)
-    vehicle_source.selected.on_change("indices", update_selection)
+    for control in (origin_filter, cylinder_filter, x_axis, y_axis):
+        control.on_change("value", performance.measure(update_filter))
+    year_filter.on_change("value_throttled", performance.measure(update_filter))
+    vehicle_source.selected.on_change("indices", performance.measure(update_selection))
     calculate_filter()
 
     attribution = Div(

--- a/apps/network/__init__.py
+++ b/apps/network/__init__.py
@@ -29,7 +29,7 @@ from bokeh.models import (
 )
 from bokeh.plotting import figure
 
-from apps._common import prepare_document, responsive_row, style_figure, wrap_row
+from apps._common import monitor_document, prepare_document, responsive_row, style_figure, wrap_row
 from apps._common.colors import CORAL, GOLD, GRID, INK, MUTED, PAPER, TEAL, VIOLET, WARM
 
 DATA = json.loads(Path(__file__).with_name("research_lineages.json").read_text())
@@ -122,6 +122,7 @@ def arc_paths(
 
 
 def modify_document(document) -> None:
+    performance = monitor_document(document, "/research-lineage")
     lineage_names = tuple(LINEAGES)
     lineage_buttons = RadioButtonGroup(
         labels=list(lineage_names),
@@ -585,12 +586,12 @@ def modify_document(document) -> None:
         state["updating"] = False
         update_inspector(paper_id)
 
-    lineage_buttons.on_change("active", lineage_changed)
-    metric_select.on_change("value", graph_changed)
-    layout_select.on_change("value", graph_changed)
-    year.on_change("value", view_changed)
-    paper_select.on_change("value", paper_changed)
-    node_source.selected.on_change("indices", graph_selected)
+    lineage_buttons.on_change("active", performance.measure(lineage_changed))
+    metric_select.on_change("value", performance.measure(graph_changed))
+    layout_select.on_change("value", performance.measure(graph_changed))
+    year.on_change("value_throttled", performance.measure(view_changed))
+    paper_select.on_change("value", performance.measure(paper_changed))
+    node_source.selected.on_change("indices", performance.measure(graph_selected))
     refresh_lineage()
 
     intro = Div(

--- a/apps/signal_studio.py
+++ b/apps/signal_studio.py
@@ -23,7 +23,15 @@ from bokeh.models import (
 from bokeh.plotting import figure
 from scipy.integrate import solve_ivp
 
-from apps._common import match_background, prepare_document, responsive_row, style_figure, wrap_row
+from apps._common import (
+    PeriodicCoalescer,
+    match_background,
+    monitor_document,
+    prepare_document,
+    responsive_row,
+    style_figure,
+    wrap_row,
+)
 from apps._common.colors import CORAL, GOLD, PAPER, PLUM, TEAL, VIOLET
 
 Acceleration = Callable[[float, float, float], float]
@@ -41,7 +49,9 @@ NARROW_CONTENT_CSS = """
 
 
 def modify_document(document) -> None:
-    advances: list[Callable[[], None]] = []
+    performance = monitor_document(document, "/chaotic-motion")
+    advances: list[Callable[[int], None]] = []
+    coalescer = PeriodicCoalescer(0.1)
 
     def build_oscillator(
         *,
@@ -71,6 +81,7 @@ def modify_document(document) -> None:
             "velocity": initial_velocity,
             "previous_velocity": initial_velocity,
             "sample": 0,
+            "updates": 0,
         }
         steps_per_period = 120
         steps_per_update = 40
@@ -259,6 +270,7 @@ def modify_document(document) -> None:
                 velocity=initial_velocity,
                 previous_velocity=initial_velocity,
                 sample=0,
+                updates=0,
             )
             trace_source.data = {"time": [0.0], "cycles": [0.0], "x": [initial_position]}
             phase_source.data = {"x": [initial_phase_position], "velocity": [initial_velocity]}
@@ -270,7 +282,7 @@ def modify_document(document) -> None:
             reset_phase_range()
             status.text = "<p>Ready from the initial state.</p>"
 
-        def advance() -> None:
+        def advance(ticks: int = 1) -> None:
             if not running.active:
                 return
             if forcing_frequency is None:
@@ -280,7 +292,8 @@ def modify_document(document) -> None:
                 frequency = float(forcing_frequency.value)
                 step = 2 * np.pi / (frequency * steps_per_period)
 
-            times = state["t"] + step * np.arange(1, steps_per_update + 1)
+            total_steps = steps_per_update * ticks
+            times = state["t"] + step * np.arange(1, total_steps + 1)
 
             def derivatives(time: float, values_at_time: np.ndarray) -> tuple[float, float]:
                 position, velocity = values_at_time
@@ -299,9 +312,9 @@ def modify_document(document) -> None:
                 status.text = f"<p>Integration stopped: {solution.message}</p>"
                 return
 
-            positions = solution.y[0].tolist()
-            velocities = solution.y[1].tolist()
-            phase_positions = [position / phase_position_scale for position in positions]
+            positions = solution.y[0]
+            velocities = solution.y[1]
+            phase_positions = positions / phase_position_scale
             sample_indices: list[int] = []
             sample_positions: list[float] = []
             sample_velocities: list[float] = []
@@ -323,30 +336,48 @@ def modify_document(document) -> None:
                 state["previous_velocity"] = velocity
 
             state["t"] = float(times[-1])
-            state["x"] = positions[-1]
-            state["velocity"] = velocities[-1]
+            state["x"] = float(positions[-1])
+            state["velocity"] = float(velocities[-1])
 
             cycles = times * frequency / (2 * np.pi) if frequency is not None else times
             trace_source.stream(
-                {"time": times.tolist(), "cycles": cycles.tolist(), "x": positions},
+                {
+                    "time": times.astype(np.float32),
+                    "cycles": cycles.astype(np.float32),
+                    "x": positions.astype(np.float32),
+                },
                 rollover=trace_history_limit,
             )
             phase_source.stream(
-                {"x": phase_positions, "velocity": velocities}, rollover=phase_history_limit
+                {
+                    "x": phase_positions.astype(np.float32),
+                    "velocity": velocities.astype(np.float32),
+                },
+                rollover=phase_history_limit,
             )
             phase_focus_source.stream(
-                {"x": phase_positions, "velocity": velocities}, rollover=phase_focus_limit
+                {
+                    "x": phase_positions.astype(np.float32),
+                    "velocity": velocities.astype(np.float32),
+                },
+                rollover=phase_focus_limit,
             )
             expand_phase_range()
             if sample_positions:
                 sample_source.stream(
-                    {"index": sample_indices, "x": sample_positions, "velocity": sample_velocities},
+                    {
+                        "index": np.asarray(sample_indices, dtype=np.int32),
+                        "x": np.asarray(sample_positions, dtype=np.float32),
+                        "velocity": np.asarray(sample_velocities, dtype=np.float32),
+                    },
                     rollover=500,
                 )
-            status.text = (
-                f"<p><strong>{state['n']:,}</strong> integration steps &nbsp; "
-                f"<strong>{len(sample_source.data['x'])}</strong> diagnostic samples</p>"
-            )
+            state["updates"] += 1
+            if state["updates"] % 5 == 0 or sample_positions:
+                status.text = (
+                    f"<p><strong>{state['n']:,}</strong> integration steps &nbsp; "
+                    f"<strong>{len(sample_source.data['x'])}</strong> diagnostic samples</p>"
+                )
 
         def parameters_changed(_attr: str, _old: object, _new: object) -> None:
             restart()
@@ -355,9 +386,9 @@ def modify_document(document) -> None:
             running.label = "Pause integration" if active else "Resume integration"
 
         for slider in controls:
-            slider.on_change("value_throttled", parameters_changed)
-        running.on_change("active", running_changed)
-        reset.on_click(restart)
+            slider.on_change("value_throttled", performance.measure(parameters_changed))
+        running.on_change("active", performance.measure(running_changed))
+        reset.on_click(performance.measure(restart))
         restart()
         advance()
         advances.append(advance)
@@ -543,8 +574,8 @@ def modify_document(document) -> None:
     tabs = Tabs(tabs=panels, active=0, sizing_mode="stretch_width", name="oscillator-tabs")
 
     def advance_active() -> None:
-        advances[tabs.active]()
+        advances[tabs.active](coalescer.due_ticks())
 
-    document.add_periodic_callback(advance_active, 100)
+    document.add_periodic_callback(performance.measure(advance_active), 100)
     document.add_root(tabs)
     prepare_document(document, "/chaotic-motion")

--- a/apps/spectrum/receiver.py
+++ b/apps/spectrum/receiver.py
@@ -9,6 +9,7 @@ import numpy as np
 from bokeh.document import Document
 from bokeh.events import Event, Tap
 
+from apps._common import PeriodicCoalescer, monitor_document
 from apps._common.colors import PLUM
 from apps.spectrum.simulation import (
     BLOCK_SIZE,
@@ -127,6 +128,7 @@ def receiver_status_html(
 class Receiver:
     view: SpectrumView
     state: ReceiverState = field(init=False)
+    coalescer: PeriodicCoalescer = field(init=False)
 
     def __post_init__(self) -> None:
         self.state = ReceiverState(
@@ -134,29 +136,31 @@ class Receiver:
             raw_history=self.view.sources.empty_history.copy(),
             raw=np.zeros(BLOCK_SIZE),
         )
+        self.coalescer = PeriodicCoalescer(0.15)
 
     def connect(self, document: Document) -> None:
+        performance = monitor_document(document, "/spectrum-monitor")
         controls = self.view.controls
-        controls.scene.on_change("value", self.scene_changed)
-        controls.filter_mode.on_change("value", self.filter_mode_changed)
+        controls.scene.on_change("value", performance.measure(self.scene_changed))
+        controls.filter_mode.on_change("value", performance.measure(self.filter_mode_changed))
         for control in (
             controls.center_frequency,
             controls.second_frequency,
             controls.bandwidth,
             controls.boost_gain,
         ):
-            control.on_change("value", self.filter_settings_changed)
-        controls.playing.on_change("active", self.playback_changed)
-        self.view.plots.spectrogram.on_event(Tap, self.tune_filter)
-        controls.inject_transient.on_click(self.queue_transient)
-        controls.restart.on_click(self.reset_signal)
+            control.on_change("value_throttled", performance.measure(self.filter_settings_changed))
+        controls.playing.on_change("active", performance.measure(self.playback_changed))
+        self.view.plots.spectrogram.on_event(Tap, performance.measure(self.tune_filter))
+        controls.inject_transient.on_click(performance.measure(self.queue_transient))
+        controls.restart.on_click(performance.measure(self.reset_signal))
         self.configure_filter_controls()
         self.reset_signal()
-        document.add_periodic_callback(self.update_receiver, 150)
+        document.add_periodic_callback(performance.measure(self.update_receiver), 150)
 
     def replace_waterfall(self, response: np.ndarray) -> None:
         self.view.sources.history.data = {
-            "image": [apply_response_db(self.state.raw_history, response)],
+            "image": [apply_response_db(self.state.raw_history, response).astype(np.float32)],
             "x": [0.0],
             "y": [-HISTORY_SECONDS],
             "dw": [NYQUIST],
@@ -164,7 +168,9 @@ class Receiver:
         }
 
     def append_waterfall_row(self, response: np.ndarray) -> None:
-        latest = apply_response_db(self.state.raw_history[-1], response)[np.newaxis, :]
+        latest = apply_response_db(self.state.raw_history[-1], response).astype(np.float32)[
+            np.newaxis, :
+        ]
         self.view.sources.latest.data = {"image": [latest]}
 
     def update_filter_view(self, *, history_update: HistoryUpdate) -> None:
@@ -196,9 +202,9 @@ class Receiver:
             }
             self.state.filter_signature = filter_signature
         sources.power.data = {
-            "frequency": frequencies,
-            "raw": raw_power,
-            "filtered": filtered_power,
+            "frequency": frequencies.astype(np.float32),
+            "raw": raw_power.astype(np.float32),
+            "filtered": filtered_power.astype(np.float32),
         }
         match history_update:
             case "replace":
@@ -279,16 +285,23 @@ class Receiver:
         controls = self.view.controls
         if not controls.playing.active and not force:
             return
-        if not force:
-            self.state.ticks += 1
-            if self.state.ticks < UPDATE_TICKS[controls.update_rate.value]:
-                return
-            self.state.ticks = 0
-        self.advance_signal()
+        if force:
+            updates = 1
+        else:
+            self.state.ticks += self.coalescer.due_ticks()
+            updates, self.state.ticks = divmod(
+                self.state.ticks, UPDATE_TICKS[controls.update_rate.value]
+            )
+        if not updates:
+            return
+        # Catch simulation time up in one callback and render only the newest measurement.
+        for _ in range(updates):
+            self.advance_signal()
         self.update_filter_view(history_update="append")
 
     def reset_signal(self) -> None:
         self.state.reset()
+        self.coalescer.reset()
         # Prime the waterfall so the first render is already informative.
         for _ in range(HISTORY_ROWS):
             self.advance_signal()
@@ -385,6 +398,8 @@ class Receiver:
 
     def playback_changed(self, _attr: str, _old: bool, active: bool) -> None:
         self.view.controls.playing.label = "Pause" if active else "Resume"
+        if active:
+            self.coalescer.reset()
 
     def tune_filter(self, event: Event) -> None:
         controls = self.view.controls

--- a/apps/task_scheduler/__init__.py
+++ b/apps/task_scheduler/__init__.py
@@ -25,7 +25,14 @@ from bokeh.models import (
 from bokeh.plotting import figure
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from apps._common import match_background, prepare_document, responsive_row, style_figure, wrap_row
+from apps._common import (
+    match_background,
+    monitor_document,
+    prepare_document,
+    responsive_row,
+    style_figure,
+    wrap_row,
+)
 from apps._common.colors import CORAL, GOLD, PAPER, PLUM, TEAL, VIOLET, WARM
 from apps.task_scheduler.simulation import (
     SEED,
@@ -72,6 +79,7 @@ TASK_HOVER_HTML = (ASSETS / "task_hover.html").read_text()
 
 
 def modify_document(document) -> None:
+    performance = monitor_document(document, "/task-scheduler")
     workload = Select(
         title="Synthetic workload",
         value="Satellite mosaic",
@@ -507,6 +515,9 @@ def modify_document(document) -> None:
         state.clock += step
         clock = state.clock
 
+        right_patches: list[tuple[int, float]] = []
+        duration_patches: list[tuple[int, float]] = []
+        result_patches: list[tuple[int, str]] = []
         for worker in workers:
             task_id = worker["task"]
             if task_id is None:
@@ -515,18 +526,20 @@ def modify_document(document) -> None:
             task["remaining"] -= step
             bar = task["bar"]
             assert bar is not None
-            stream_source.patch(
-                {
-                    "right": [(bar, clock)],
-                    "duration": [(bar, clock - cast(float, stream_source.data["left"][bar]))],
-                }
-            )
+            right_patches.append((bar, clock))
+            duration_patches.append((bar, clock - cast(float, stream_source.data["left"][bar])))
             if task["remaining"] <= 0:
                 set_status(task, "Complete")
                 task["worker"] = None
                 result = "Straggler complete" if task["straggler"] else "Complete"
-                stream_source.patch({"result": [(bar, result)]})
+                result_patches.append((bar, result))
                 worker["task"] = None
+
+        if right_patches:
+            patches: dict[str, Any] = {"right": right_patches, "duration": duration_patches}
+            if result_patches:
+                patches["result"] = result_patches
+            stream_source.patch(cast(Any, patches))
 
         refresh_ready()
         ready = [task for task in tasks if task["status"] == "Ready"]
@@ -608,16 +621,16 @@ def modify_document(document) -> None:
         )
         update_summary()
 
-    workload.on_change("value", settings_changed)
-    worker_count.on_change("value", settings_changed)
-    playing.on_change("active", playback_changed)
-    critical_path.on_change("active", critical_changed)
-    node_source.selected.on_change("indices", selection_changed)
-    straggler.on_click(slow_task)
-    fail_worker.on_click(interrupt_worker)
-    restart.on_click(reset_simulation)
+    workload.on_change("value", performance.measure(settings_changed))
+    worker_count.on_change("value_throttled", performance.measure(settings_changed))
+    playing.on_change("active", performance.measure(playback_changed))
+    critical_path.on_change("active", performance.measure(critical_changed))
+    node_source.selected.on_change("indices", performance.measure(selection_changed))
+    straggler.on_click(performance.measure(slow_task))
+    fail_worker.on_click(performance.measure(interrupt_worker))
+    restart.on_click(performance.measure(reset_simulation))
     reset_simulation()
-    document.add_periodic_callback(advance, 150)
+    document.add_periodic_callback(performance.measure(advance), 150)
 
     controls = column(
         Div(text=INTRO_HTML, css_classes=["scheduler-introduction"], stylesheets=[SCHEDULER_CSS]),

--- a/apps/terrain/__init__.py
+++ b/apps/terrain/__init__.py
@@ -9,6 +9,7 @@ from bokeh.layouts import column
 from bokeh.models import (
     Button,
     ColumnDataSource,
+    CustomJS,
     Div,
     HoverTool,
     LabelSet,
@@ -25,6 +26,7 @@ from apps._common import (
     match_background,
     metric,
     metric_row,
+    monitor_document,
     prepare_document,
     responsive_row,
     set_metric,
@@ -63,6 +65,7 @@ TOGGLE_STYLESHEET = """
 
 
 def modify_document(document) -> None:
+    performance = monitor_document(document, "/terrain-contours")
     landform_options = list(LANDFORMS)
     landform = Select(
         title="Modeled landform",
@@ -78,7 +81,49 @@ def modify_document(document) -> None:
     )
     reset = Button(label="Reset horizontal transect")
 
-    transect_source = ColumnDataSource(data=dict(DEFAULT_TRANSECT), name="terrain-transect")
+    # Keep drag feedback in BokehJS and send at most five profile requests per second.
+    transect_source = ColumnDataSource(
+        data=dict(DEFAULT_TRANSECT), name="terrain-transect", syncable=False
+    )
+    transect_request = ColumnDataSource(
+        data=dict(DEFAULT_TRANSECT), name="terrain-transect-request"
+    )
+    transect_source.js_on_change(
+        "data",
+        CustomJS(
+            args={"request": transect_request},
+            code="""
+                const throttle = cb_obj.tags[0] ?? {last_sent: 0, timeout: null}
+                const send_request = () => {
+                    const data = cb_obj.data
+                    const unchanged = ["x", "y", "label"].every((name) =>
+                        data[name].length == request.data[name].length &&
+                        data[name].every((value, index) => value == request.data[name][index])
+                    )
+                    if (!unchanged) {
+                        request.data = {
+                            x: Array.from(data.x),
+                            y: Array.from(data.y),
+                            label: Array.from(data.label),
+                        }
+                        request.change.emit()
+                    }
+                    throttle.last_sent = Date.now()
+                    throttle.timeout = null
+                }
+
+                const remaining = 200 - (Date.now() - throttle.last_sent)
+                if (remaining <= 0) {
+                    clearTimeout(throttle.timeout)
+                    send_request()
+                } else {
+                    clearTimeout(throttle.timeout)
+                    throttle.timeout = setTimeout(send_request, remaining)
+                }
+                cb_obj.tags = [throttle]
+            """,
+        ),
+    )
     profile_source = ColumnDataSource(
         data={"distance": np.zeros(241), "elevation": np.zeros(241)}, name="terrain-profile"
     )
@@ -191,14 +236,19 @@ def modify_document(document) -> None:
     current_z = z
 
     def update_profile() -> None:
-        coordinates = transect_source.data
+        coordinates = transect_request.data
         if len(coordinates["x"]) != 2 or len(coordinates["y"]) != 2:
             reading.text = "<p><strong>Two handles are required.</strong><br>Reset the transect to restore them.</p>"
             return
         x0, x1 = map(float, coordinates["x"])
         y0, y1 = map(float, coordinates["y"])
         distance, values = sample_transect(current_z, x0, y0, x1, y1)
-        profile_source.data = {"distance": distance, "elevation": values}
+        profile_source.patch(
+            {
+                "distance": [(slice(len(distance)), distance)],
+                "elevation": [(slice(len(values)), values)],
+            }
+        )
         profile_range.end = max(float(distance[-1]), 0.1)
         peak_index = int(np.argmax(values))
         angle = np.degrees(np.arctan2(y1 - y0, x1 - x0))
@@ -234,11 +284,12 @@ def modify_document(document) -> None:
 
     def reset_transect() -> None:
         transect_source.data = dict(DEFAULT_TRANSECT)
+        transect_request.data = dict(DEFAULT_TRANSECT)
 
-    landform.on_change("value", choose_landform)
-    transect_source.on_change("data", move_transect)
-    outlines.on_change("active", toggle_outlines)
-    reset.on_click(reset_transect)
+    landform.on_change("value", performance.measure(choose_landform))
+    transect_request.on_change("data", performance.measure(move_transect))
+    outlines.on_change("active", performance.measure(toggle_outlines))
+    reset.on_click(performance.measure(reset_transect))
     update_terrain()
 
     introduction = Div(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,87 @@
+# Production operations
+
+The application repository owns container releases. The `bokeh/infra`
+repository owns the ECS service, load balancer, ECR repository, IAM roles, and
+other AWS resources. A routine application release does not require Terraform.
+
+## Automated release
+
+Pull requests run the Python checks, tests, and a local container build. They do
+not publish images or change AWS.
+
+Every merge to `main` starts the **Publish and deploy** workflow. It:
+
+1. assumes `demo-bokeh-org-github-deploy` through GitHub OIDC;
+2. builds a Linux ARM64 image and pushes the immutable `sha-<commit>` tag to ECR;
+3. resolves that tag to an image digest;
+4. registers a new `demo-bokeh-org` task-definition revision;
+5. updates ECS service `demo-bokeh-org/worker` and waits for stability; and
+6. requests `https://demo.bokeh.org/healthz` before reporting success.
+
+Allow several minutes for an uncached ARM64 build and the ECS connection-drain
+period. The first end-to-end production rehearsal took about nine minutes; a
+previously published commit skips the image build.
+
+The workflow summary records the deployed digest. In AWS, follow the rollout at
+**ECS → Clusters → demo-bokeh-org → Services → worker → Deployments**. The
+**Events** tab reports task-start, target-registration, and rollback failures.
+Application output is in CloudWatch log group `/ecs/demo-bokeh-org`.
+
+After the workflow succeeds, open the landing page and at least one streaming
+application. A useful smoke test is `/spectrum-monitor`: let the waterfall run,
+change a filter, and confirm that the page continues updating over its WebSocket.
+
+To roll back, revert the change on `main`. For a faster emergency rollback,
+rerun a previously successful **Publish and deploy** workflow; its immutable
+commit image can be reused without rebuilding.
+
+## Performance telemetry
+
+Every application records Python callback duration and event-loop scheduling
+lag per browser session. Summaries are emitted as compact JSON once per minute
+and when a session closes. The instrumentation does not send metrics through
+the Bokeh document or add anything to the page. Set `DEMO_PERFORMANCE=0` to
+disable both callback wrapping and the one-second lag observer locally. Normal
+idle lag windows are suppressed; callback-active windows and lag spikes are
+retained.
+
+Callback records use event `demo.callback` and include `app`, `callback`,
+`count`, `mean_ms`, `p95_ms`, and `max_ms`. Event-loop records use
+`demo.event_loop_lag` and the same timing fields. A lag spike means work in the
+process kept the session's one-second observer from running on schedule.
+
+The Terraform-managed CloudWatch dashboard `demo-bokeh-org-performance`
+summarizes callback p95 and maximum duration, event-loop lag by app, and the
+slowest named callbacks over the selected time range. Its Logs Insights queries
+run when the dashboard loads or refreshes.
+
+For raw records, open **CloudWatch → Logs Insights**, select
+`/ecs/demo-bokeh-org`, and use:
+
+```text
+fields @timestamp, app, callback, count, mean_ms, p95_ms, max_ms
+| filter event = "demo.callback"
+| sort p95_ms desc
+| limit 100
+```
+
+For scheduling lag:
+
+```text
+fields @timestamp, app, count, mean_ms, p95_ms, max_ms
+| filter event = "demo.event_loop_lag"
+| sort p95_ms desc
+| limit 100
+```
+
+Compare those session-level measurements with:
+
+- **ECS service metrics** for aggregate CPU and memory;
+- **ALB TargetResponseTime** for document and HTTP response latency;
+- **ALB HTTPCode_Target_5XX_Count** and ECS service events for failures; and
+- task count and capacity provider in the ECS service when autoscaling occurs.
+
+Low aggregate CPU does not rule out a slow callback. A single session can block
+on an expensive calculation while the service-wide five-minute average remains
+small. Start with callback p95 and maximum duration, then check whether the same
+window has event-loop lag or an ALB latency spike.

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -32,6 +32,7 @@ def test_weather_compares_year_with_full_record() -> None:
     assert monthly.data["outline_width"].count(1.5) == 12
     initial_heavy_days = selected.data["rain_color"].tolist().count(CORAL)
     threshold.value = 5
+    threshold.trigger("value_throttled", threshold.value_throttled, threshold.value)
     assert selected.data["rain_color"].tolist().count(CORAL) > initial_heavy_days
     assert threshold_span.location == 5
     assert "5 mm threshold" in summary.text

--- a/tests/test_image_lab.py
+++ b/tests/test_image_lab.py
@@ -21,6 +21,10 @@ def test_hubble_filters_and_editable_crop_update_the_result() -> None:
     processed = document.select_one({"type": ColumnDataSource, "name": "hubble-processed-image"})
     crop_box = document.select_one({"type": BoxAnnotation, "name": "hubble-crop-box"})
     crop_handles = document.select_one({"type": ColumnDataSource, "name": "hubble-crop-handles"})
+    crop_request = document.select_one({"type": ColumnDataSource, "name": "hubble-crop-request"})
+    strength_request = document.select_one(
+        {"type": ColumnDataSource, "name": "hubble-strength-request"}
+    )
     report = document.select_one({"type": Div, "name": "hubble-processing-report"})
     source_plot = document.select_one({"name": "hubble-source-plot"})
     processed_plot = document.select_one({"name": "hubble-processed-plot"})
@@ -31,6 +35,8 @@ def test_hubble_filters_and_editable_crop_update_the_result() -> None:
     assert reset_crop.margin == (22, 0, 0, 0)
     assert reset_crop.height == 31
     assert not crop_box.editable
+    assert not crop_box.syncable
+    assert not crop_handles.syncable
     assert set(source_plot.js_event_callbacks) == {"panstart", "pan", "panend"}
     pan_callback = source_plot.js_event_callbacks["pan"][0]
     assert "box.update" in pan_callback.code
@@ -47,6 +53,9 @@ def test_hubble_filters_and_editable_crop_update_the_result() -> None:
     strength = next(
         slider for slider in document.select({"type": Slider}) if slider.title == "Edge gain"
     )
+    assert not strength.syncable
+    assert "change:value" in strength.js_property_callbacks
+    assert "change:value_throttled" in strength.js_property_callbacks
     results = []
     for option in operation.options:
         operation.value = option
@@ -58,9 +67,10 @@ def test_hubble_filters_and_editable_crop_update_the_result() -> None:
 
     operation.value = "Sobel edges"
     edges = processed.data["image"][0].copy()
-    strength.value = 3.0
+    strength_request.data = {"value": [3.0]}
     assert not np.array_equal(edges, processed.data["image"][0])
 
     crop_box.update(left=0, right=0.48, bottom=1 - 480 / 872, top=1)
+    crop_request.data = {"left": [0], "right": [0.48], "bottom": [1 - 480 / 872], "top": [1]}
     assert "x=0:480" in report.text
     assert "y=0:480" in report.text

--- a/tests/test_market_monitor.py
+++ b/tests/test_market_monitor.py
@@ -95,7 +95,7 @@ def test_market_streams_one_intraday_bar_at_each_update() -> None:
     assert source.data["index"] == previous_indices
     previous_date = source.data["date"][-1]
     speed.value = "Fast"
-    next(iter(document.session_callbacks)).callback()
+    min(document.session_callbacks, key=lambda callback: callback.period).callback()
     assert len(source.data["date"]) == 64
     assert source.data["index"] == [*previous_indices[1:], previous_indices[-1] + 1]
     assert source.data["date"][-1] > previous_date

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -113,6 +113,7 @@ def test_research_lineage_links_time_selection_and_ranking() -> None:
 
     initial_count = len(nodes.data["index"])
     year.value = year.start
+    year.trigger("value_throttled", year.value_throttled, year.value)
     assert len(nodes.data["index"]) < initial_count
     assert all(
         relation != "Follow-on" or published <= year.value

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,75 @@
+"""Test shared demo performance instrumentation."""
+
+from __future__ import annotations
+
+import json
+from time import perf_counter
+
+from bokeh.document import Document
+
+from apps._common.performance import LOGGER, PerformanceMonitor, monitor_document
+
+
+def test_performance_monitor_reports_callback_duration(monkeypatch) -> None:
+    messages: list[str] = []
+    monkeypatch.setattr(LOGGER, "info", messages.append)
+    monitor = PerformanceMonitor("/example")
+
+    @monitor.measure
+    def calculate(value: int) -> int:
+        return value * 2
+
+    assert calculate(3) == 6
+    monitor.report(force=True)
+
+    payload = json.loads(messages[-1])
+    assert payload["event"] == "demo.callback"
+    assert payload["app"] == "/example"
+    assert payload["callback"] == "calculate"
+    assert payload["count"] == 1
+    assert payload["mean_ms"] >= 0
+    assert payload["p95_ms"] >= 0
+    assert payload["max_ms"] >= 0
+
+
+def test_monitor_document_samples_event_loop_lag_once_per_document(monkeypatch) -> None:
+    messages: list[str] = []
+    monkeypatch.setattr(LOGGER, "info", messages.append)
+    document = Document()
+    monitor = monitor_document(document, "/example")
+    monitor.start(document)
+    monitor.start(document)
+    assert len(document.session_callbacks) == 1
+
+    monitor.last_loop_time = perf_counter() - 1.025
+    document.session_callbacks[0].callback()
+    monitor.report(force=True)
+
+    payload = json.loads(messages[-1])
+    assert payload["event"] == "demo.event_loop_lag"
+    assert payload["app"] == "/example"
+    assert payload["count"] == 1
+    assert payload["max_ms"] >= 20
+
+
+def test_disabled_performance_monitor_is_a_no_op() -> None:
+    document = Document()
+    monitor = PerformanceMonitor("/example", enabled=False)
+
+    def calculate(value: int) -> int:
+        return value * 2
+
+    assert monitor.measure(calculate) is calculate
+    monitor.start(document)
+    assert document.session_callbacks == []
+
+
+def test_performance_monitor_suppresses_normal_idle_lag(monkeypatch) -> None:
+    messages: list[str] = []
+    monkeypatch.setattr(LOGGER, "info", messages.append)
+    monitor = PerformanceMonitor("/example")
+    monitor.event_loop_lag.add(1.5)
+
+    monitor.report(force=True)
+
+    assert messages == []

--- a/tests/test_signal_studio.py
+++ b/tests/test_signal_studio.py
@@ -101,7 +101,7 @@ def test_oscillator_phase_range_expands_to_contain_the_orbit() -> None:
     )
     nonlinearity.value = nonlinearity.end
     for _ in range(50):
-        document.session_callbacks[0].callback()
+        min(document.session_callbacks, key=lambda callback: callback.period).callback()
 
     phase = document.select_one({"name": "van-der-pol-phase-plot"})
     source = document.select_one({"type": ColumnDataSource, "name": "van-der-pol-phase"})
@@ -123,7 +123,7 @@ def test_pendulum_ticks_remain_readable_across_multiple_rotations() -> None:
     )
     damping.value = damping.start
     for _ in range(40):
-        document.session_callbacks[0].callback()
+        min(document.session_callbacks, key=lambda callback: callback.period).callback()
 
     phase = document.select_one({"name": "pendulum-phase-plot"})
     phase_source = document.select_one({"name": "pendulum-phase"})
@@ -142,7 +142,7 @@ def test_mathieu_oscillator_streams_a_finite_stroboscopic_section() -> None:
     tabs = document.select_one({"type": Tabs, "name": "oscillator-tabs"})
     tabs.active = 3
     for _ in range(20):
-        document.session_callbacks[0].callback()
+        min(document.session_callbacks, key=lambda callback: callback.period).callback()
 
     phase = document.select_one({"type": ColumnDataSource, "name": "mathieu-phase"})
     diagnostic = document.select_one({"type": ColumnDataSource, "name": "mathieu-diagnostic"})
@@ -178,7 +178,7 @@ def test_oscillator_tabs_own_their_controls_and_only_advance_when_active() -> No
     }
     lengths = {name: len(source.data["time"]) for name, source in traces.items()}
     tabs.active = 1
-    document.session_callbacks[0].callback()
+    min(document.session_callbacks, key=lambda callback: callback.period).callback()
     assert len(traces["duffing-trace"].data["time"]) == lengths["duffing-trace"]
     assert len(traces["van-der-pol-trace"].data["time"]) > lengths["van-der-pol-trace"]
     assert len(traces["pendulum-trace"].data["time"]) == lengths["pendulum-trace"]

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -30,8 +30,9 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
     previous_history = history.data["image"][0].copy()
     previous_latest = latest.data["image"][0].copy()
     previous_response = response.data["gain"].copy()
-    document.session_callbacks[0].callback()
-    document.session_callbacks[0].callback()
+    periodic = min(document.session_callbacks, key=lambda callback: callback.period)
+    periodic.callback()
+    periodic.callback()
     assert np.array_equal(history.data["image"][0], previous_history)
     assert not np.array_equal(latest.data["image"][0], previous_latest)
     assert np.array_equal(response.data["gain"], previous_response)
@@ -73,8 +74,9 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
     receiver_filter.value = "No filter"
     assert not np.array_equal(history.data["image"][0], notch_history)
     receiver_filter.value = "Notch"
-    document.session_callbacks[0].callback()
-    document.session_callbacks[0].callback()
+    periodic = min(document.session_callbacks, key=lambda callback: callback.period)
+    periodic.callback()
+    periodic.callback()
     assert not np.array_equal(power.data["raw"], power.data["filtered"])
     filter_histories = {}
     for option in receiver_filter.options:
@@ -107,6 +109,7 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
     layout_updates = []
     specialized_controls.on_change("children", lambda _attr, _old, new: layout_updates.append(new))
     bandwidth.value += 5
+    bandwidth.trigger("value_throttled", bandwidth.value_throttled, bandwidth.value)
     assert layout_updates == []
     frequency = response.data["frequency"]
     first_index = int(np.argmin(np.abs(frequency - center.value)))
@@ -127,6 +130,7 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
     adaptive_latest = latest.data["image"][0].copy()
     adaptive_response = response.data["gain"].copy()
     bandwidth.value += 10
+    bandwidth.trigger("value_throttled", bandwidth.value_throttled, bandwidth.value)
     assert np.array_equal(history.data["image"][0], adaptive_history)
     assert np.array_equal(latest.data["image"][0], adaptive_latest)
     assert not np.array_equal(response.data["gain"], adaptive_response)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,20 @@
+"""Test shared streaming update helpers."""
+
+from __future__ import annotations
+
+from apps._common.streaming import PeriodicCoalescer
+
+
+def test_periodic_coalescer_batches_delay_and_bounds_backlog() -> None:
+    coalescer = PeriodicCoalescer(0.1, max_ticks=4)
+    assert coalescer.due_ticks(now=1.0) == 1
+    assert coalescer.due_ticks(now=1.1) == 1
+    assert coalescer.due_ticks(now=1.4) == 3
+    assert coalescer.due_ticks(now=2.4) == 4
+
+
+def test_periodic_coalescer_reset_discards_elapsed_time() -> None:
+    coalescer = PeriodicCoalescer(0.2)
+    coalescer.due_ticks(now=1.0)
+    coalescer.reset(now=3.0)
+    assert coalescer.due_ticks(now=3.2) == 1

--- a/tests/test_task_scheduler.py
+++ b/tests/test_task_scheduler.py
@@ -27,7 +27,7 @@ def test_task_scheduler_streams_state_without_rebuilding_the_graph() -> None:
     original_edges = dict(edges.data)
     initial_bars = len(stream.data["task"])
     for _ in range(12):
-        document.session_callbacks[0].callback()
+        min(document.session_callbacks, key=lambda callback: callback.period).callback()
     assert len(stream.data["task"]) > initial_bars
     assert edges.data["start"] == original_edges["start"]
     assert edges.data["end"] == original_edges["end"]
@@ -65,7 +65,7 @@ def test_task_scheduler_streams_state_without_rebuilding_the_graph() -> None:
         in document.select_one({"name": "scheduler-task-details"}).text
     )
     for _ in range(10):
-        document.session_callbacks[0].callback()
+        min(document.session_callbacks, key=lambda callback: callback.period).callback()
     assert not (
         any(
             worker == interrupted_worker and left > interrupted_at
@@ -82,7 +82,7 @@ def test_task_scheduler_streams_state_without_rebuilding_the_graph() -> None:
     assert len(interruptions.data["event"]) == 1
     assert "Injected delay: 18 s" in document.select_one({"name": "scheduler-task-details"}).text
     for _ in range(220):
-        document.session_callbacks[0].callback()
+        min(document.session_callbacks, key=lambda callback: callback.period).callback()
     assert max(stream.data["run"]) >= 2
     assert next(
         toggle for toggle in document.select({"type": Toggle}) if toggle.label == "Pause scheduler"
@@ -98,5 +98,6 @@ def test_task_scheduler_streams_state_without_rebuilding_the_graph() -> None:
     assert len(workload.options) >= 8
     workload.value = "Storm forecast ensemble"
     workers.value = 3
+    workers.trigger("value_throttled", workers.value_throttled, workers.value)
     assert task_stream.y_range.factors == ["Worker 3", "Worker 2", "Worker 1"]
     assert len(nodes.data["index"]) >= 40

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -113,8 +113,12 @@ def test_terrain_has_multiple_landforms_and_a_movable_transect() -> None:
     assert len(handle_hovers) == 1
     assert handle_hovers[0].tooltips is None
     source = document.select_one({"type": ColumnDataSource, "name": "terrain-transect"})
+    request = document.select_one({"type": ColumnDataSource, "name": "terrain-transect-request"})
     profile = document.select_one({"type": ColumnDataSource, "name": "terrain-profile"})
+    assert not source.syncable
+    assert "setTimeout" in source.js_property_callbacks["change:data"][0].code
     source.data = {"x": [-3.0, 3.0], "y": [-2.0, 2.0], "label": ["A", "B"]}
+    request.data = dict(source.data)
     assert profile.data["distance"][-1] == pytest.approx(math.hypot(6, 4), abs=5e-8)
     reset = next(
         button
@@ -124,3 +128,4 @@ def test_terrain_has_multiple_landforms_and_a_movable_transect() -> None:
     reset._trigger_event(ButtonClick(reset))
     assert source.data["x"] == [-4.5, 4.5]
     assert source.data["y"] == [0.0, 0.0]
+    assert request.data["x"] == source.data["x"]

--- a/tests/test_wave_field.py
+++ b/tests/test_wave_field.py
@@ -46,6 +46,7 @@ def test_wave_field_uses_webgl() -> None:
         slider for slider in document.select({"type": Slider}) if slider.title == "Cross-section y"
     )
     cross_section.value = 0.05
+    cross_section.trigger("value_throttled", cross_section.value_throttled, cross_section.value)
     x = section.data["x"][0]
     expected = math.sin(1.8 * x) * math.cos(1.8 * cross_section.value) + 0.7 * math.sin(
         x * cross_section.value


### PR DESCRIPTION
## Summary

- measure Python callback duration and event-loop lag per demo session, emitting compact structured summaries for CloudWatch Logs Insights
- reduce interaction latency by throttling drag callbacks, coalescing streaming updates, and using smaller document patches where practical
- document deployment, rollback, and performance investigation workflows
- add coverage for the telemetry and shared streaming helpers

## Why

The Fargate service has ample aggregate CPU, but an expensive callback can still block one session and every drag event currently pays the network round trip to AWS. These changes reduce avoidable patch traffic while making the remaining app-level hotspots observable without publishing high-cardinality custom metrics.

The corresponding Terraform dashboard is being proposed separately in `bokeh/infra`.

## Validation

- `uv run --locked ruff format --no-cache --check .`
- `uv run --locked ruff check --no-cache .`
- `uv run --locked pyright`
- `uv run --locked pytest` (245 passed)
