### PR TITLE
Reduce interactive callback latency

### DIFF
--- a/apps/_common/__init__.py
+++ b/apps/_common/__init__.py
@@ -24,6 +24,7 @@ from catalog import DEMOS
 from presentation import SITE, configure_document
 
 from . import colors
+from .callbacks import on_throttled_value as on_throttled_value
 from .performance import monitor_document
 from .streaming import PeriodicCoalescer as PeriodicCoalescer
 

--- a/apps/_common/callbacks.py
+++ b/apps/_common/callbacks.py
@@ -1,0 +1,39 @@
+"""Connect browser-throttled controls to Python callbacks."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from bokeh.models import ColumnDataSource, CustomJS, Slider
+
+THROTTLED_SLIDER_JS = Path(__file__).with_name("throttled_slider.js").read_text()
+
+
+def on_throttled_value(
+    slider: Slider,
+    callback: Callable[[str, object, object], None],
+    *,
+    wait: int = 100,
+    name: str | None = None,
+) -> ColumnDataSource:
+    """Run a Python slider callback at most once per ``wait`` milliseconds while dragging."""
+    if wait <= 0:
+        raise ValueError("wait must be positive")
+
+    slider.syncable = False
+    request = ColumnDataSource(data={"value": [slider.value]}, name=name)
+    browser_callback = CustomJS(
+        args={"request": request}, code=f"const wait = {wait}\n{THROTTLED_SLIDER_JS}"
+    )
+    slider.js_on_change("value", browser_callback)
+    slider.js_on_change("value_throttled", browser_callback)
+
+    def forward_value(_attr: str, _old: object, new: dict[str, list[float]]) -> None:
+        old_value = slider.value
+        new_value = new["value"][0]
+        slider.value = new_value
+        callback("value", old_value, new_value)
+
+    request.on_change("data", forward_value)
+    return request

--- a/apps/_common/throttled_slider.js
+++ b/apps/_common/throttled_slider.js
@@ -1,0 +1,21 @@
+const throttle = cb_obj.tags[0] ?? {last_sent: 0, timeout: null}
+const send_request = () => {
+  const value = cb_obj.value
+  if (request.data.value[0] != value) {
+    request.data = {value: [value]}
+    request.change.emit()
+  }
+  throttle.last_sent = Date.now()
+  throttle.timeout = null
+}
+
+const finished = cb_obj.value == cb_obj.value_throttled
+const remaining = wait - (Date.now() - throttle.last_sent)
+if (finished || remaining <= 0) {
+  clearTimeout(throttle.timeout)
+  send_request()
+} else {
+  clearTimeout(throttle.timeout)
+  throttle.timeout = setTimeout(send_request, remaining)
+}
+cb_obj.tags = [throttle]

--- a/apps/airport_map.py
+++ b/apps/airport_map.py
@@ -336,12 +336,15 @@ def modify_document(document) -> None:
             representative = int(np.argmin(squared_distance))
             anchor.value = str(region.loc[representative, "iata"])
 
+    @performance.measure
     def choose_state(_attr: str, _old: object, _new: object) -> None:
         update_state()
 
+    @performance.measure
     def choose_airport(_attr: str, _old: object, _new: object) -> None:
         update_airport()
 
+    @performance.measure
     def tap_airport(_attr: str, _old: list[int], indices: list[int]) -> None:
         if indices:
             selected_iata = str(airport_source.data["iata"][indices[0]])
@@ -354,9 +357,9 @@ def modify_document(document) -> None:
                 anchor.options = [(selected_iata, label), *options]
             anchor.value = selected_iata
 
-    state.on_change("value", performance.measure(choose_state))
-    anchor.on_change("value", performance.measure(choose_airport))
-    airport_source.selected.on_change("indices", performance.measure(tap_airport))
+    state.on_change("value", choose_state)
+    anchor.on_change("value", choose_airport)
+    airport_source.selected.on_change("indices", tap_airport)
     update_state()
 
     introduction = Div(

--- a/apps/cellular_automata/__init__.py
+++ b/apps/cellular_automata/__init__.py
@@ -405,6 +405,7 @@ def modify_document(document) -> None:
         history_range.end = max(30, generation + 1)
         history_range.start = max(0, history_range.end - 30)
 
+    @performance.measure
     def load_seed() -> None:
         field = seed_field(seed.value, density.value, state.rng)
         state.field = field
@@ -423,6 +424,7 @@ def modify_document(document) -> None:
         reset_history()
         render()
 
+    @performance.measure
     def advance(*, force: bool = False) -> None:
         if not state.running and not force:
             return
@@ -495,6 +497,7 @@ def modify_document(document) -> None:
             }
         )
 
+    @performance.measure
     def edit_field(event: Event) -> None:
         if not isinstance(event, Tap) or event.x is None or event.y is None:
             return
@@ -536,6 +539,7 @@ def modify_document(document) -> None:
         update_latest_history()
         render()
 
+    @performance.measure
     def clear_field() -> None:
         state.running = False
         playing.label = "Resume evolution"
@@ -555,15 +559,18 @@ def modify_document(document) -> None:
         reset_history()
         render()
 
+    @performance.measure
     def seed_changed(_attr: str, _old: object, _new: object) -> None:
         load_seed()
 
+    @performance.measure
     def rule_changed(_attr: str, _old: object, _new: object) -> None:
         update_rule_builder_visibility()
         reset_cycle_tracking()
         update_notes()
         update_status()
 
+    @performance.measure
     def comparison_rule_changed(_attr: str, _old: object, _new: object) -> None:
         update_rule_builder_visibility()
         state.comparison_seen.clear()
@@ -572,12 +579,14 @@ def modify_document(document) -> None:
         update_notes()
         update_status()
 
+    @performance.measure
     def primary_custom_rule_changed(_attr: str, _old: object, _new: object) -> None:
         if rule.value == CUSTOM_RULE:
             reset_cycle_tracking()
             update_notes()
             update_status()
 
+    @performance.measure
     def comparison_custom_rule_changed(_attr: str, _old: object, _new: object) -> None:
         if comparing() and comparison_rule.value == CUSTOM_RULE:
             state.comparison_seen.clear()
@@ -586,6 +595,7 @@ def modify_document(document) -> None:
             update_notes()
             update_status()
 
+    @performance.measure
     def density_changed(_attr: str, _old: object, _new: object) -> None:
         if seed.value == "Random soup":
             load_seed()
@@ -595,9 +605,11 @@ def modify_document(document) -> None:
         playing.label = "Pause evolution" if running else "Resume evolution"
         playing.button_type = "primary" if running else "default"
 
+    @performance.measure
     def toggle_playing() -> None:
         set_running(not state.running)
 
+    @performance.measure
     def toggle_wrap() -> None:
         state.wrap = not state.wrap
         wrap_edges.label = f"Edges wrap · {'on' if state.wrap else 'off'}"
@@ -646,6 +658,7 @@ def modify_document(document) -> None:
         update_notes()
         render()
 
+    @performance.measure
     def experiment_changed(_attr: str, _old: object, _new: object) -> None:
         if comparing():
             state.comparison_field = state.field.copy()
@@ -656,6 +669,7 @@ def modify_document(document) -> None:
             update_latest_history()
         update_visual_mode()
 
+    @performance.measure
     def brush_changed(_attr: str, _old: object, _new: object) -> None:
         is_pattern = BRUSHES[brush.value] is not None
         rotate_pattern.visible = is_pattern
@@ -664,38 +678,44 @@ def modify_document(document) -> None:
             set_running(False)
         update_brush_note()
 
+    @performance.measure
     def rotate_brush() -> None:
         state.brush_rotation = (state.brush_rotation + 1) % 4
         rotate_pattern.label = f"Rotation · {90 * state.brush_rotation}°"
 
+    @performance.measure
     def flip_brush() -> None:
         state.brush_flipped = not state.brush_flipped
         flip_pattern.label = f"Mirror · {'on' if state.brush_flipped else 'off'}"
 
-    experiment.on_change("value", performance.measure(experiment_changed))
-    seed.on_change("value", performance.measure(seed_changed))
-    rule.on_change("value", performance.measure(rule_changed))
-    comparison_rule.on_change("value", performance.measure(comparison_rule_changed))
-    primary_birth.on_change("value", performance.measure(primary_custom_rule_changed))
-    primary_survival.on_change("value", performance.measure(primary_custom_rule_changed))
-    comparison_birth.on_change("value", performance.measure(comparison_custom_rule_changed))
-    comparison_survival.on_change("value", performance.measure(comparison_custom_rule_changed))
-    brush.on_change("value", performance.measure(brush_changed))
-    density.on_change("value_throttled", performance.measure(density_changed))
-    playing.on_click(performance.measure(toggle_playing))
-    wrap_edges.on_click(performance.measure(toggle_wrap))
-    rotate_pattern.on_click(performance.measure(rotate_brush))
-    flip_pattern.on_click(performance.measure(flip_brush))
-    restart.on_click(performance.measure(load_seed))
-    step.on_click(performance.measure(lambda: advance(force=True), name="step_once"))
-    clear.on_click(performance.measure(clear_field))
-    field_plot.on_event(Tap, performance.measure(edit_field))
+    @performance.measure
+    def step_once() -> None:
+        advance(force=True)
+
+    experiment.on_change("value", experiment_changed)
+    seed.on_change("value", seed_changed)
+    rule.on_change("value", rule_changed)
+    comparison_rule.on_change("value", comparison_rule_changed)
+    primary_birth.on_change("value", primary_custom_rule_changed)
+    primary_survival.on_change("value", primary_custom_rule_changed)
+    comparison_birth.on_change("value", comparison_custom_rule_changed)
+    comparison_survival.on_change("value", comparison_custom_rule_changed)
+    brush.on_change("value", brush_changed)
+    density.on_change("value_throttled", density_changed)
+    playing.on_click(toggle_playing)
+    wrap_edges.on_click(toggle_wrap)
+    rotate_pattern.on_click(rotate_brush)
+    flip_pattern.on_click(flip_brush)
+    restart.on_click(load_seed)
+    step.on_click(step_once)
+    clear.on_click(clear_field)
+    field_plot.on_event(Tap, edit_field)
 
     update_notes()
     update_brush_note()
     load_seed()
     update_visual_mode()
-    document.add_periodic_callback(performance.measure(advance), 100)
+    document.add_periodic_callback(advance, 100)
 
     controls = column(
         Div(

--- a/apps/climate.py
+++ b/apps/climate.py
@@ -385,12 +385,13 @@ def modify_document(document) -> None:
             f"exceeded the {threshold:.0f} mm threshold; the yearly average was {average_heavy_days:.1f}.</p>"
         )
 
+    @performance.measure
     def update(_attr: str, _old: object, _new: object) -> None:
         calculate()
 
-    year.on_change("value", performance.measure(update))
-    smoothing.on_change("value_throttled", performance.measure(update))
-    heavy_rain.on_change("value_throttled", performance.measure(update))
+    year.on_change("value", update)
+    smoothing.on_change("value_throttled", update)
+    heavy_rain.on_change("value_throttled", update)
     calculate()
 
     attribution = Div(

--- a/apps/heatmap.py
+++ b/apps/heatmap.py
@@ -24,6 +24,7 @@ from apps._common import (
     metric,
     metric_row,
     monitor_document,
+    on_throttled_value,
     prepare_document,
     responsive_row,
     set_metric,
@@ -235,20 +236,23 @@ def modify_document(document) -> None:
         set_metric(energy_card, f"{np.mean(values**2):.2f}")
         update_section()
 
+    @performance.measure
     def update_field(_attr: str, _old: object, _new: object) -> None:
         calculate_field()
 
+    @performance.measure
     def update_cross_section(_attr: str, _old: object, _new: object) -> None:
         update_section()
 
+    @performance.measure
     def update_palette(_attr: str, _old: object, _new: object) -> None:
         mapper.palette = palettes[palette.value]
 
-    field.on_change("value", performance.measure(update_field))
-    palette.on_change("value", performance.measure(update_palette))
-    frequency.on_change("value_throttled", performance.measure(update_field))
-    coupling.on_change("value_throttled", performance.measure(update_field))
-    cross_section.on_change("value_throttled", performance.measure(update_cross_section))
+    field.on_change("value", update_field)
+    palette.on_change("value", update_palette)
+    on_throttled_value(frequency, update_field, name="wave-frequency-request")
+    on_throttled_value(coupling, update_field, name="wave-coupling-request")
+    on_throttled_value(cross_section, update_cross_section, name="wave-cross-section-request")
     calculate_field()
 
     controls = column(

--- a/apps/image_lab/__init__.py
+++ b/apps/image_lab/__init__.py
@@ -98,7 +98,7 @@ def modify_document(document) -> None:
                     throttle.last_sent = Date.now()
                     throttle.timeout = null
                 }
-                const remaining = 200 - (Date.now() - throttle.last_sent)
+                const remaining = 100 - (Date.now() - throttle.last_sent)
                 if (remaining <= 0) {
                     clearTimeout(throttle.timeout)
                     send_request()
@@ -302,9 +302,11 @@ def modify_document(document) -> None:
         crop["y"] = (y_low, y_high)
         calculate()
 
+    @performance.measure
     def update_crop(_attr: str, _old: object, _new: object) -> None:
         apply_crop()
 
+    @performance.measure
     def restore_crop() -> None:
         crop["x"] = (260, 740)
         crop["y"] = (196, 676)
@@ -312,6 +314,7 @@ def modify_document(document) -> None:
         crop_handles.data = dict(initial_crop_handles)
         crop_request.data = {name: [value] for name, value in initial_crop_box.items()}
 
+    @performance.measure
     def configure_filter(_attr: str, _old: object, _new: object) -> None:
         image_filter = FILTERS[operation.value]
         slider = image_filter.slider
@@ -329,15 +332,16 @@ def modify_document(document) -> None:
         operation_note.text = f"<p>{image_filter.description}</p>"
         calculate()
 
+    @performance.measure
     def update_strength(_attr: str, _old: object, _new: object) -> None:
         if not configuring["operation"]:
             strength.value = float(cast(float, strength_request.data["value"][0]))
             calculate()
 
-    operation.on_change("value", performance.measure(configure_filter))
-    strength_request.on_change("data", performance.measure(update_strength))
-    reset_crop.on_click(performance.measure(restore_crop))
-    crop_request.on_change("data", performance.measure(update_crop))
+    operation.on_change("value", configure_filter)
+    strength_request.on_change("data", update_strength)
+    reset_crop.on_click(restore_crop)
+    crop_request.on_change("data", update_crop)
     configure_filter("value", None, operation.value)
 
     intro = Div(

--- a/apps/image_lab/update_crop_box.js
+++ b/apps/image_lab/update_crop_box.js
@@ -36,7 +36,7 @@ handles.change.emit()
 // Preserve smooth browser-side motion while limiting expensive Python image work.
 const now = Date.now()
 const last_sent = state.tags[0] ?? 0
-if (now - last_sent >= 200) {
+if (now - last_sent >= 100) {
   request.data = {left: [left], right: [right], bottom: [bottom], top: [top]}
   request.change.emit()
   state.tags = [now]

--- a/apps/market_monitor.py
+++ b/apps/market_monitor.py
@@ -353,6 +353,7 @@ def modify_document(document) -> None:
         for plot in (price, volume, macd):
             plot.xaxis[0].major_label_overrides = cast(Any, labels)
 
+    @performance.measure
     def reset_simulation() -> None:
         state.update(
             rng=np.random.default_rng(SEED),
@@ -372,6 +373,7 @@ def modify_document(document) -> None:
         update_summary()
         coalescer.reset()
 
+    @performance.measure
     def advance(*, force: bool = False) -> None:
         if not playing.active and not force:
             return
@@ -390,26 +392,29 @@ def modify_document(document) -> None:
         append_indicators(candles)
         update_summary()
 
+    @performance.measure
     def regime_changed(_attr: str, _old: object, _new: object) -> None:
         update_regime_note()
         reset_simulation()
 
+    @performance.measure
     def playback_changed(_attr: str, _old: bool, active: bool) -> None:
         playing.label = "Pause simulation" if active else "Resume simulation"
         if active:
             coalescer.reset()
 
+    @performance.measure
     def inject_selloff() -> None:
         state["shock"] = -0.08
         if not playing.active:
             advance(force=True)
 
-    regime.on_change("value", performance.measure(regime_changed))
-    playing.on_change("active", performance.measure(playback_changed))
-    selloff.on_click(performance.measure(inject_selloff))
-    restart.on_click(performance.measure(reset_simulation))
+    regime.on_change("value", regime_changed)
+    playing.on_change("active", playback_changed)
+    selloff.on_click(inject_selloff)
+    restart.on_click(reset_simulation)
     reset_simulation()
-    document.add_periodic_callback(performance.measure(advance), 150)
+    document.add_periodic_callback(advance, 150)
 
     key = Div(
         text=(

--- a/apps/mobility.py
+++ b/apps/mobility.py
@@ -197,16 +197,18 @@ def modify_document(document) -> None:
         vehicle_source.selected.indices = []
         update_analysis(np.array([], dtype=int))
 
+    @performance.measure
     def update_filter(_attr: str, _old: object, _new: object) -> None:
         calculate_filter()
 
+    @performance.measure
     def update_selection(_attr: str, _old: list[int], indices: list[int]) -> None:
         update_analysis(np.asarray(indices, dtype=int))
 
     for control in (origin_filter, cylinder_filter, x_axis, y_axis):
-        control.on_change("value", performance.measure(update_filter))
-    year_filter.on_change("value_throttled", performance.measure(update_filter))
-    vehicle_source.selected.on_change("indices", performance.measure(update_selection))
+        control.on_change("value", update_filter)
+    year_filter.on_change("value_throttled", update_filter)
+    vehicle_source.selected.on_change("indices", update_selection)
     calculate_filter()
 
     attribution = Div(

--- a/apps/network/__init__.py
+++ b/apps/network/__init__.py
@@ -560,23 +560,28 @@ def modify_document(document) -> None:
         update_timeline()
         update_graph()
 
+    @performance.measure
     def lineage_changed(_attr: str, _old: object, _new: object) -> None:
         if not state["updating"]:
             refresh_lineage()
 
+    @performance.measure
     def view_changed(_attr: str, _old: object, _new: object) -> None:
         if not state["updating"]:
             update_timeline()
             update_graph()
 
+    @performance.measure
     def graph_changed(_attr: str, _old: object, _new: object) -> None:
         if not state["updating"]:
             update_graph()
 
+    @performance.measure
     def paper_changed(_attr: str, _old: object, paper_id: str) -> None:
         if not state["updating"] and paper_id:
             update_inspector(paper_id)
 
+    @performance.measure
     def graph_selected(_attr: str, _old: list[int], indices: list[int]) -> None:
         if state["updating"] or not indices:
             return
@@ -586,12 +591,12 @@ def modify_document(document) -> None:
         state["updating"] = False
         update_inspector(paper_id)
 
-    lineage_buttons.on_change("active", performance.measure(lineage_changed))
-    metric_select.on_change("value", performance.measure(graph_changed))
-    layout_select.on_change("value", performance.measure(graph_changed))
-    year.on_change("value_throttled", performance.measure(view_changed))
-    paper_select.on_change("value", performance.measure(paper_changed))
-    node_source.selected.on_change("indices", performance.measure(graph_selected))
+    lineage_buttons.on_change("active", lineage_changed)
+    metric_select.on_change("value", graph_changed)
+    layout_select.on_change("value", graph_changed)
+    year.on_change("value_throttled", view_changed)
+    paper_select.on_change("value", paper_changed)
+    node_source.selected.on_change("indices", graph_selected)
     refresh_lineage()
 
     intro = Div(

--- a/apps/signal_studio.py
+++ b/apps/signal_studio.py
@@ -379,16 +379,22 @@ def modify_document(document) -> None:
                     f"<strong>{len(sample_source.data['x'])}</strong> diagnostic samples</p>"
                 )
 
+        @performance.measure
         def parameters_changed(_attr: str, _old: object, _new: object) -> None:
             restart()
 
+        @performance.measure
         def running_changed(_attr: str, _old: bool, active: bool) -> None:
             running.label = "Pause integration" if active else "Resume integration"
 
+        @performance.measure
+        def reset_oscillator() -> None:
+            restart()
+
         for slider in controls:
-            slider.on_change("value_throttled", performance.measure(parameters_changed))
-        running.on_change("active", performance.measure(running_changed))
-        reset.on_click(performance.measure(restart))
+            slider.on_change("value_throttled", parameters_changed)
+        running.on_change("active", running_changed)
+        reset.on_click(reset_oscillator)
         restart()
         advance()
         advances.append(advance)
@@ -573,9 +579,10 @@ def modify_document(document) -> None:
 
     tabs = Tabs(tabs=panels, active=0, sizing_mode="stretch_width", name="oscillator-tabs")
 
+    @performance.measure
     def advance_active() -> None:
         advances[tabs.active](coalescer.due_ticks())
 
-    document.add_periodic_callback(performance.measure(advance_active), 100)
+    document.add_periodic_callback(advance_active, 100)
     document.add_root(tabs)
     prepare_document(document, "/chaotic-motion")

--- a/apps/spectrum/receiver.py
+++ b/apps/spectrum/receiver.py
@@ -9,7 +9,7 @@ import numpy as np
 from bokeh.document import Document
 from bokeh.events import Event, Tap
 
-from apps._common import PeriodicCoalescer, monitor_document
+from apps._common import PeriodicCoalescer, monitor_document, on_throttled_value
 from apps._common.colors import PLUM
 from apps.spectrum.simulation import (
     BLOCK_SIZE,
@@ -31,7 +31,7 @@ from apps.spectrum.view import (
     SpectrumView,
 )
 
-type HistoryUpdate = Literal["append", "preserve", "replace"]
+type HistoryUpdate = Literal["append", "refresh", "replace"]
 type FilterSignature = tuple[str, float, float, float, float]
 
 
@@ -149,7 +149,11 @@ class Receiver:
             controls.bandwidth,
             controls.boost_gain,
         ):
-            control.on_change("value_throttled", performance.measure(self.filter_settings_changed))
+            on_throttled_value(
+                control,
+                performance.measure(self.filter_settings_changed),
+                name=f"{control.name}-request",
+            )
         controls.playing.on_change("active", performance.measure(self.playback_changed))
         self.view.plots.spectrogram.on_event(Tap, performance.measure(self.tune_filter))
         controls.inject_transient.on_click(performance.measure(self.queue_transient))
@@ -167,11 +171,11 @@ class Receiver:
             "dh": [HISTORY_SECONDS],
         }
 
-    def append_waterfall_row(self, response: np.ndarray) -> None:
+    def update_waterfall_row(self, response: np.ndarray, *, advance: bool) -> None:
         latest = apply_response_db(self.state.raw_history[-1], response).astype(np.float32)[
             np.newaxis, :
         ]
-        self.view.sources.latest.data = {"image": [latest]}
+        self.view.sources.latest.data = {"image": [latest], "advance": [advance]}
 
     def update_filter_view(self, *, history_update: HistoryUpdate) -> None:
         controls = self.view.controls
@@ -210,9 +214,9 @@ class Receiver:
             case "replace":
                 self.replace_waterfall(response)
             case "append":
-                self.append_waterfall_row(response)
-            case "preserve":
-                pass
+                self.update_waterfall_row(response, advance=True)
+            case "refresh":
+                self.update_waterfall_row(response, advance=False)
             case _:
                 raise ValueError(history_update)
 
@@ -382,19 +386,12 @@ class Receiver:
                 controls.bandwidth.title = "Notch spacing (Hz)"
 
     def filter_settings_changed(self, _attr: str, _old: object, _new: object) -> None:
-        # Adaptive settings affect new measurements; manual settings reprocess visible history.
-        self.update_filter_view(
-            history_update=(
-                "preserve"
-                if self.view.controls.filter_mode.value == "Adaptive notch"
-                else "replace"
-            )
-        )
+        # A filter change updates the newest measurement without rewriting recorded history.
+        self.update_filter_view(history_update="refresh")
 
-    def filter_mode_changed(self, _attr: str, old: object, new: object) -> None:
+    def filter_mode_changed(self, _attr: str, _old: object, _new: object) -> None:
         self.configure_filter_controls()
-        history_update: HistoryUpdate = "preserve" if "Adaptive notch" in (old, new) else "replace"
-        self.update_filter_view(history_update=history_update)
+        self.update_filter_view(history_update="refresh")
 
     def playback_changed(self, _attr: str, _old: bool, active: bool) -> None:
         self.view.controls.playing.label = "Pause" if active else "Resume"

--- a/apps/spectrum/shift_history.js
+++ b/apps/spectrum/shift_history.js
@@ -1,6 +1,6 @@
 const image = history.data.image[0]
 const latest = cb_obj.data.image[0]
 const width = image.shape[1]
-image.copyWithin(0, width)
+if (cb_obj.data.advance?.[0] ?? true) image.copyWithin(0, width)
 image.set(latest, image.length - width)
 history.change.emit()

--- a/apps/spectrum/view.py
+++ b/apps/spectrum/view.py
@@ -231,9 +231,10 @@ def build_sources() -> Sources:
         name="spectrum-history",
     )
     latest = ColumnDataSource(
-        data={"image": [empty_history[-1][np.newaxis, :].copy()]}, name="spectrum-latest-row"
+        data={"image": [empty_history[-1][np.newaxis, :].copy()], "advance": [False]},
+        name="spectrum-latest-row",
     )
-    # Send one row per update; BokehJS shifts it into the existing waterfall buffer.
+    # Send one row per update; BokehJS either refreshes the top row or advances the buffer.
     latest.js_on_change(
         "data",
         CustomJS(args={"history": history}, code=load_javascript(__file__, "shift_history.js")),
@@ -403,8 +404,8 @@ def build_layout(controls: Controls, plots: Plots, status: Div) -> Column:
         Div(
             text=(
                 '<h2 style="margin:0 0 5px">Tune the receiver</h2>'
-                '<p style="margin:0">All three displays share the same frequency axis. Manual filters can be '
-                "retuned across the visible history; adaptive changes apply only to new measurements.</p>"
+                '<p style="margin:0">All three displays share the same frequency axis. Filter changes update '
+                "the current measurement; recorded rows keep the settings used when they arrived.</p>"
             )
         ),
         controls.primary,
@@ -429,8 +430,8 @@ def build_layout(controls: Controls, plots: Plots, status: Div) -> Column:
         text=(
             f"<p><strong>Simulation:</strong> every signal is generated from a reproducible model with seed "
             f"<code>{SEED}</code>. Each update streams one filtered <code>float32</code> spectrum row through "
-            "Bokeh's binary transport. Manual filter changes reprocess the visible history, while adaptive "
-            "settings affect only subsequent rows. The display contains no captured or licensed radio traffic.</p>"
+            "Bokeh's binary transport. Filter changes refresh only the newest row, so the waterfall remains "
+            "a faithful history of settings over time. The display contains no captured or licensed radio traffic.</p>"
         )
     )
     return column(controls_layout, console, note, sizing_mode="stretch_width", spacing=10)

--- a/apps/task_scheduler/__init__.py
+++ b/apps/task_scheduler/__init__.py
@@ -425,6 +425,7 @@ def modify_document(document) -> None:
         refresh_ready()
         update_graph_styles()
 
+    @performance.measure
     def reset_simulation() -> None:
         workload_name = cast(WorkloadName, workload.value)
         definition = WORKLOADS[workload_name]
@@ -506,6 +507,7 @@ def modify_document(document) -> None:
         for _ in range(12):
             advance(force=True)
 
+    @performance.measure
     def advance(*, force: bool = False) -> None:
         if not playing.active and not force:
             return
@@ -555,18 +557,23 @@ def modify_document(document) -> None:
             start_next_run()
         update_summary()
 
+    @performance.measure
     def selection_changed(_attr: str, _old: object, indices: list[int]) -> None:
         show_task(indices[0] if indices else None)
 
+    @performance.measure
     def settings_changed(_attr: str, _old: object, _new: object) -> None:
         reset_simulation()
 
+    @performance.measure
     def playback_changed(_attr: str, _old: bool, active: bool) -> None:
         playing.label = "Pause scheduler" if active else "Resume scheduler"
 
+    @performance.measure
     def critical_changed(_attr: str, _old: bool, _new: bool) -> None:
         update_graph_styles()
 
+    @performance.measure
     def slow_task() -> None:
         tasks = state.tasks
         running = [task for task in tasks if task["status"] == "Running" and not task["straggler"]]
@@ -590,6 +597,7 @@ def modify_document(document) -> None:
         update_graph_styles()
         show_task(task["id"])
 
+    @performance.measure
     def interrupt_worker() -> None:
         tasks = state.tasks
         workers = state.workers
@@ -621,16 +629,16 @@ def modify_document(document) -> None:
         )
         update_summary()
 
-    workload.on_change("value", performance.measure(settings_changed))
-    worker_count.on_change("value_throttled", performance.measure(settings_changed))
-    playing.on_change("active", performance.measure(playback_changed))
-    critical_path.on_change("active", performance.measure(critical_changed))
-    node_source.selected.on_change("indices", performance.measure(selection_changed))
-    straggler.on_click(performance.measure(slow_task))
-    fail_worker.on_click(performance.measure(interrupt_worker))
-    restart.on_click(performance.measure(reset_simulation))
+    workload.on_change("value", settings_changed)
+    worker_count.on_change("value_throttled", settings_changed)
+    playing.on_change("active", playback_changed)
+    critical_path.on_change("active", critical_changed)
+    node_source.selected.on_change("indices", selection_changed)
+    straggler.on_click(slow_task)
+    fail_worker.on_click(interrupt_worker)
+    restart.on_click(reset_simulation)
     reset_simulation()
-    document.add_periodic_callback(performance.measure(advance), 150)
+    document.add_periodic_callback(advance, 150)
 
     controls = column(
         Div(text=INTRO_HTML, css_classes=["scheduler-introduction"], stylesheets=[SCHEDULER_CSS]),

--- a/apps/terrain/__init__.py
+++ b/apps/terrain/__init__.py
@@ -81,7 +81,7 @@ def modify_document(document) -> None:
     )
     reset = Button(label="Reset horizontal transect")
 
-    # Keep drag feedback in BokehJS and send at most five profile requests per second.
+    # Keep drag feedback in BokehJS and send at most ten profile requests per second.
     transect_source = ColumnDataSource(
         data=dict(DEFAULT_TRANSECT), name="terrain-transect", syncable=False
     )
@@ -112,7 +112,7 @@ def modify_document(document) -> None:
                     throttle.timeout = null
                 }
 
-                const remaining = 200 - (Date.now() - throttle.last_sent)
+                const remaining = 100 - (Date.now() - throttle.last_sent)
                 if (remaining <= 0) {
                     clearTimeout(throttle.timeout)
                     send_request()
@@ -271,25 +271,29 @@ def modify_document(document) -> None:
         set_metric(grade_card, f"{np.hypot(dx, dy).max() / 10:.0f}%")
         update_profile()
 
+    @performance.measure
     def choose_landform(_attr: str, _old: object, _new: object) -> None:
         update_terrain()
 
+    @performance.measure
     def move_transect(_attr: str, _old: object, _new: object) -> None:
         update_profile()
 
+    @performance.measure
     def toggle_outlines(_attr: str, _old: bool, active: bool) -> None:
         contours.fill_renderer.visible = True
         contours.line_renderer.visible = active
         outlines.label = "Hide contour outlines" if active else "Show contour outlines"
 
+    @performance.measure
     def reset_transect() -> None:
         transect_source.data = dict(DEFAULT_TRANSECT)
         transect_request.data = dict(DEFAULT_TRANSECT)
 
-    landform.on_change("value", performance.measure(choose_landform))
-    transect_request.on_change("data", performance.measure(move_transect))
-    outlines.on_change("active", performance.measure(toggle_outlines))
-    reset.on_click(performance.measure(reset_transect))
+    landform.on_change("value", choose_landform)
+    transect_request.on_change("data", move_transect)
+    outlines.on_change("active", toggle_outlines)
+    reset.on_click(reset_transect)
     update_terrain()
 
     introduction = Div(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,30 @@
+"""Test shared callback helpers."""
+
+from __future__ import annotations
+
+from bokeh.models import Slider
+
+from apps._common.callbacks import on_throttled_value
+
+
+def test_on_throttled_value_forwards_requests_and_flushes_on_release() -> None:
+    slider = Slider(start=0, end=10, value=2)
+    changes: list[tuple[object, object]] = []
+
+    request = on_throttled_value(
+        slider,
+        lambda _attr, old, new: changes.append((old, new)),
+        wait=100,
+        name="test-slider-request",
+    )
+    request.data = {"value": [7]}
+
+    assert not slider.syncable
+    assert slider.value == 7
+    assert changes == [(2, 7)]
+    callbacks = slider.js_property_callbacks
+    assert set(callbacks) == {"change:value", "change:value_throttled"}
+    assert all(
+        "const wait = 100" in callback.code for group in callbacks.values() for callback in group
+    )
+    assert all("setTimeout" in callback.code for group in callbacks.values() for callback in group)

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -35,6 +35,7 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
     periodic.callback()
     assert np.array_equal(history.data["image"][0], previous_history)
     assert not np.array_equal(latest.data["image"][0], previous_latest)
+    assert latest.data["advance"] == [True]
     assert np.array_equal(response.data["gain"], previous_response)
     signal_scene = next(
         select for select in document.select({"type": Select}) if select.title == "Signal scene"
@@ -67,30 +68,29 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
         "Comb reject",
     } <= set(receiver_filter.options)
     band_pass_history = history.data["image"][0].copy()
+    band_pass_latest = latest.data["image"][0].copy()
     receiver_filter.value = "Notch"
-    assert not np.array_equal(history.data["image"][0], band_pass_history)
+    assert np.array_equal(history.data["image"][0], band_pass_history)
+    assert not np.array_equal(latest.data["image"][0], band_pass_latest)
+    assert latest.data["advance"] == [False]
     assert not np.array_equal(response.data["gain"], previous_response)
-    notch_history = history.data["image"][0].copy()
     receiver_filter.value = "No filter"
-    assert not np.array_equal(history.data["image"][0], notch_history)
+    assert np.array_equal(history.data["image"][0], band_pass_history)
     receiver_filter.value = "Notch"
     periodic = min(document.session_callbacks, key=lambda callback: callback.period)
     periodic.callback()
     periodic.callback()
     assert not np.array_equal(power.data["raw"], power.data["filtered"])
-    filter_histories = {}
     for option in receiver_filter.options:
         receiver_filter.value = option
-        filter_histories[option] = history.data["image"][0].copy()
-    for first, second in zip(receiver_filter.options, receiver_filter.options[1:], strict=False):
-        if "Adaptive notch" in (first, second):
-            assert np.array_equal(filter_histories[first], filter_histories[second])
-            continue
-        assert not np.array_equal(filter_histories[first], filter_histories[second])
+        assert np.array_equal(history.data["image"][0], band_pass_history)
+        assert latest.data["advance"] == [False]
     spectrum = document.select_one({"name": "spectrum-power-plot"})
     assert spectrum.output_backend == "canvas"
     center = document.select_one({"type": Slider, "name": "spectrum-center-frequency"})
     bandwidth = document.select_one({"type": Slider, "name": "spectrum-bandwidth"})
+    assert not bandwidth.syncable
+    assert set(bandwidth.js_property_callbacks) == {"change:value", "change:value_throttled"}
     primary_controls = document.select_one({"name": "spectrum-primary-controls"})
     specialized_controls = document.select_one({"name": "spectrum-specialized-controls"})
     noise_control = document.select_one({"type": Slider, "name": "spectrum-noise"})
@@ -108,8 +108,10 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
     assert bandwidth.value == 100
     layout_updates = []
     specialized_controls.on_change("children", lambda _attr, _old, new: layout_updates.append(new))
-    bandwidth.value += 5
-    bandwidth.trigger("value_throttled", bandwidth.value_throttled, bandwidth.value)
+    bandwidth_request = document.select_one(
+        {"type": ColumnDataSource, "name": "spectrum-bandwidth-request"}
+    )
+    bandwidth_request.data = {"value": [bandwidth.value + 5]}
     assert layout_updates == []
     frequency = response.data["frequency"]
     first_index = int(np.argmin(np.abs(frequency - center.value)))
@@ -129,10 +131,10 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
     adaptive_history = history.data["image"][0].copy()
     adaptive_latest = latest.data["image"][0].copy()
     adaptive_response = response.data["gain"].copy()
-    bandwidth.value += 10
-    bandwidth.trigger("value_throttled", bandwidth.value_throttled, bandwidth.value)
+    bandwidth_request.data = {"value": [bandwidth.value + 10]}
     assert np.array_equal(history.data["image"][0], adaptive_history)
-    assert np.array_equal(latest.data["image"][0], adaptive_latest)
+    assert not np.array_equal(latest.data["image"][0], adaptive_latest)
+    assert latest.data["advance"] == [False]
     assert not np.array_equal(response.data["gain"], adaptive_response)
     receiver_filter.value = "No filter"
     assert np.array_equal(history.data["image"][0], adaptive_history)

--- a/tests/test_wave_field.py
+++ b/tests/test_wave_field.py
@@ -45,8 +45,10 @@ def test_wave_field_uses_webgl() -> None:
     cross_section = next(
         slider for slider in document.select({"type": Slider}) if slider.title == "Cross-section y"
     )
-    cross_section.value = 0.05
-    cross_section.trigger("value_throttled", cross_section.value_throttled, cross_section.value)
+    assert not cross_section.syncable
+    assert set(cross_section.js_property_callbacks) == {"change:value", "change:value_throttled"}
+    request = document.select_one({"type": ColumnDataSource, "name": "wave-cross-section-request"})
+    request.data = {"value": [0.05]}
     x = section.data["x"][0]
     expected = math.sin(1.8 * x) * math.cos(1.8 * cross_section.value) + 0.7 * math.sin(
         x * cross_section.value


### PR DESCRIPTION
## Summary

- make callback performance instrumentation declarative with decorators
- add a shared 100 ms slider bridge so expensive Python updates remain responsive without firing on every browser event
- preserve the spectrum waterfall as recorded history while refreshing only its newest row when filter controls change
- extend tests for throttled controls and incremental spectrum updates

## Why

AWS adds roughly one network round trip to every Python callback. Sending every intermediate slider value and replacing already-rendered waterfall history made otherwise modest calculations feel sluggish. This keeps immediate browser-side feedback while reducing server traffic and document patch volume.

## Validation

- `uv run --locked pre-commit run --all-files`
- `uv run --locked pytest` (246 passed)
