### PR TITLE
Fix initial slider throttling

### DIFF
--- a/apps/_common/callbacks.py
+++ b/apps/_common/callbacks.py
@@ -23,11 +23,17 @@ def on_throttled_value(
 
     slider.syncable = False
     request = ColumnDataSource(data={"value": [slider.value]}, name=name)
-    browser_callback = CustomJS(
-        args={"request": request}, code=f"const wait = {wait}\n{THROTTLED_SLIDER_JS}"
-    )
-    slider.js_on_change("value", browser_callback)
-    slider.js_on_change("value_throttled", browser_callback)
+
+    def browser_callback(*, flush: bool) -> CustomJS:
+        return CustomJS(
+            args={"request": request},
+            code=f"const wait = {wait}\nconst flush = {str(flush).lower()}\n{THROTTLED_SLIDER_JS}",
+        )
+
+    # ``value_throttled`` is unset in BokehJS until the first completed interaction.
+    # Keep the drag callback independent of it, and flush through a separate final callback.
+    slider.js_on_change("value", browser_callback(flush=False))
+    slider.js_on_change("value_throttled", browser_callback(flush=True))
 
     def forward_value(_attr: str, _old: object, new: dict[str, list[float]]) -> None:
         old_value = slider.value

--- a/apps/_common/throttled_slider.js
+++ b/apps/_common/throttled_slider.js
@@ -9,9 +9,8 @@ const send_request = () => {
   throttle.timeout = null
 }
 
-const finished = cb_obj.value == cb_obj.value_throttled
 const remaining = wait - (Date.now() - throttle.last_sent)
-if (finished || remaining <= 0) {
+if (flush || remaining <= 0) {
   clearTimeout(throttle.timeout)
   send_request()
 } else {

--- a/apps/spectrum/receiver.py
+++ b/apps/spectrum/receiver.py
@@ -31,7 +31,7 @@ from apps.spectrum.view import (
     SpectrumView,
 )
 
-type HistoryUpdate = Literal["append", "refresh", "replace"]
+type HistoryUpdate = Literal["append", "replace"]
 type FilterSignature = tuple[str, float, float, float, float]
 
 
@@ -171,11 +171,11 @@ class Receiver:
             "dh": [HISTORY_SECONDS],
         }
 
-    def update_waterfall_row(self, response: np.ndarray, *, advance: bool) -> None:
+    def append_waterfall_row(self, response: np.ndarray) -> None:
         latest = apply_response_db(self.state.raw_history[-1], response).astype(np.float32)[
             np.newaxis, :
         ]
-        self.view.sources.latest.data = {"image": [latest], "advance": [advance]}
+        self.view.sources.latest.data = {"image": [latest]}
 
     def update_filter_view(self, *, history_update: HistoryUpdate) -> None:
         controls = self.view.controls
@@ -214,9 +214,7 @@ class Receiver:
             case "replace":
                 self.replace_waterfall(response)
             case "append":
-                self.update_waterfall_row(response, advance=True)
-            case "refresh":
-                self.update_waterfall_row(response, advance=False)
+                self.append_waterfall_row(response)
             case _:
                 raise ValueError(history_update)
 
@@ -386,12 +384,11 @@ class Receiver:
                 controls.bandwidth.title = "Notch spacing (Hz)"
 
     def filter_settings_changed(self, _attr: str, _old: object, _new: object) -> None:
-        # A filter change updates the newest measurement without rewriting recorded history.
-        self.update_filter_view(history_update="refresh")
+        self.update_filter_view(history_update="replace")
 
     def filter_mode_changed(self, _attr: str, _old: object, _new: object) -> None:
         self.configure_filter_controls()
-        self.update_filter_view(history_update="refresh")
+        self.update_filter_view(history_update="replace")
 
     def playback_changed(self, _attr: str, _old: bool, active: bool) -> None:
         self.view.controls.playing.label = "Pause" if active else "Resume"

--- a/apps/spectrum/shift_history.js
+++ b/apps/spectrum/shift_history.js
@@ -1,6 +1,6 @@
 const image = history.data.image[0]
 const latest = cb_obj.data.image[0]
 const width = image.shape[1]
-if (cb_obj.data.advance?.[0] ?? true) image.copyWithin(0, width)
+image.copyWithin(0, width)
 image.set(latest, image.length - width)
 history.change.emit()

--- a/apps/spectrum/view.py
+++ b/apps/spectrum/view.py
@@ -231,10 +231,9 @@ def build_sources() -> Sources:
         name="spectrum-history",
     )
     latest = ColumnDataSource(
-        data={"image": [empty_history[-1][np.newaxis, :].copy()], "advance": [False]},
-        name="spectrum-latest-row",
+        data={"image": [empty_history[-1][np.newaxis, :].copy()]}, name="spectrum-latest-row"
     )
-    # Send one row per update; BokehJS either refreshes the top row or advances the buffer.
+    # Send one row per update; BokehJS shifts it into the existing waterfall buffer.
     latest.js_on_change(
         "data",
         CustomJS(args={"history": history}, code=load_javascript(__file__, "shift_history.js")),
@@ -344,7 +343,7 @@ def build_plots(sources: Sources) -> Plots:
     style_instrument(response)
 
     spectrogram = figure(
-        title=f"Filtered waterfall · newest signal at top, {HISTORY_SECONDS:.0f} seconds of history",
+        title=f"Filtered waterfall · newest signal at top, {HISTORY_SECONDS:.0f}-second window",
         height=475,
         sizing_mode="stretch_width",
         x_range=frequency_range,
@@ -404,8 +403,8 @@ def build_layout(controls: Controls, plots: Plots, status: Div) -> Column:
         Div(
             text=(
                 '<h2 style="margin:0 0 5px">Tune the receiver</h2>'
-                '<p style="margin:0">All three displays share the same frequency axis. Filter changes update '
-                "the current measurement; recorded rows keep the settings used when they arrived.</p>"
+                '<p style="margin:0">All three displays share the same frequency axis. Filter changes reprocess '
+                "the entire visible window so their effect is immediately comparable.</p>"
             )
         ),
         controls.primary,
@@ -430,8 +429,8 @@ def build_layout(controls: Controls, plots: Plots, status: Div) -> Column:
         text=(
             f"<p><strong>Simulation:</strong> every signal is generated from a reproducible model with seed "
             f"<code>{SEED}</code>. Each update streams one filtered <code>float32</code> spectrum row through "
-            "Bokeh's binary transport. Filter changes refresh only the newest row, so the waterfall remains "
-            "a faithful history of settings over time. The display contains no captured or licensed radio traffic.</p>"
+            "Bokeh's binary transport. Filter changes reprocess the visible window from the retained raw signal. "
+            "The display contains no captured or licensed radio traffic.</p>"
         )
     )
     return column(controls_layout, console, note, sizing_mode="stretch_width", spacing=10)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -24,7 +24,10 @@ def test_on_throttled_value_forwards_requests_and_flushes_on_release() -> None:
     assert changes == [(2, 7)]
     callbacks = slider.js_property_callbacks
     assert set(callbacks) == {"change:value", "change:value_throttled"}
-    assert all(
-        "const wait = 100" in callback.code for group in callbacks.values() for callback in group
-    )
-    assert all("setTimeout" in callback.code for group in callbacks.values() for callback in group)
+    value_callback = callbacks["change:value"][0]
+    final_callback = callbacks["change:value_throttled"][0]
+    assert "const wait = 100" in value_callback.code
+    assert "const flush = false" in value_callback.code
+    assert "value_throttled" not in value_callback.code
+    assert "const flush = true" in final_callback.code
+    assert "setTimeout" in value_callback.code

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -35,7 +35,6 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
     periodic.callback()
     assert np.array_equal(history.data["image"][0], previous_history)
     assert not np.array_equal(latest.data["image"][0], previous_latest)
-    assert latest.data["advance"] == [True]
     assert np.array_equal(response.data["gain"], previous_response)
     signal_scene = next(
         select for select in document.select({"type": Select}) if select.title == "Signal scene"
@@ -68,23 +67,23 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
         "Comb reject",
     } <= set(receiver_filter.options)
     band_pass_history = history.data["image"][0].copy()
-    band_pass_latest = latest.data["image"][0].copy()
     receiver_filter.value = "Notch"
-    assert np.array_equal(history.data["image"][0], band_pass_history)
-    assert not np.array_equal(latest.data["image"][0], band_pass_latest)
-    assert latest.data["advance"] == [False]
+    assert not np.array_equal(history.data["image"][0], band_pass_history)
     assert not np.array_equal(response.data["gain"], previous_response)
+    notch_history = history.data["image"][0].copy()
     receiver_filter.value = "No filter"
-    assert np.array_equal(history.data["image"][0], band_pass_history)
+    assert not np.array_equal(history.data["image"][0], notch_history)
     receiver_filter.value = "Notch"
     periodic = min(document.session_callbacks, key=lambda callback: callback.period)
     periodic.callback()
     periodic.callback()
     assert not np.array_equal(power.data["raw"], power.data["filtered"])
+    filter_histories = {}
     for option in receiver_filter.options:
         receiver_filter.value = option
-        assert np.array_equal(history.data["image"][0], band_pass_history)
-        assert latest.data["advance"] == [False]
+        filter_histories[option] = history.data["image"][0].copy()
+    for first, second in zip(receiver_filter.options, receiver_filter.options[1:], strict=False):
+        assert not np.array_equal(filter_histories[first], filter_histories[second])
     spectrum = document.select_one({"name": "spectrum-power-plot"})
     assert spectrum.output_backend == "canvas"
     center = document.select_one({"type": Slider, "name": "spectrum-center-frequency"})
@@ -129,14 +128,11 @@ def test_spectrum_streams_float32_history_and_filtered_power() -> None:
     receiver_filter.value = "Adaptive notch"
     assert not center.visible
     adaptive_history = history.data["image"][0].copy()
-    adaptive_latest = latest.data["image"][0].copy()
     adaptive_response = response.data["gain"].copy()
     bandwidth_request.data = {"value": [bandwidth.value + 10]}
-    assert np.array_equal(history.data["image"][0], adaptive_history)
-    assert not np.array_equal(latest.data["image"][0], adaptive_latest)
-    assert latest.data["advance"] == [False]
+    assert not np.array_equal(history.data["image"][0], adaptive_history)
     assert not np.array_equal(response.data["gain"], adaptive_response)
     receiver_filter.value = "No filter"
-    assert np.array_equal(history.data["image"][0], adaptive_history)
+    assert not np.array_equal(history.data["image"][0], adaptive_history)
     console = document.select_one({"name": "spectrum-console"})
     assert console.styles["background"] == PLUM


### PR DESCRIPTION
## Summary

- deliver throttled slider updates during the very first drag
- keep a separate final callback that flushes the settled slider value
- restore full waterfall reprocessing when spectrum filter settings change
- describe the waterfall as a visible time window rather than immutable filter history

## Root cause

BokehJS leaves `value_throttled` unset until a slider completes its first interaction. The shared bridge read that property from the ordinary `value` callback, so the first drag raised internally until mouse-up initialized it.

The spectrum optimization introduced in #26 refreshed only the newest waterfall row. Although efficient, it made the filter guide and live spectrum visually disagree with earlier rows. The raw spectra are already retained, so this restores a consistent filter across the complete visible window while periodic updates continue to send only one binary `float32` row.

## Validation

- `uv run --locked pre-commit run --all-files`
- `uv run --locked pytest` (246 passed)
