### PR TITLE
Prevent monitor self-observation

### DIFF
--- a/apps/_common/__init__.py
+++ b/apps/_common/__init__.py
@@ -55,14 +55,15 @@ def demo_for_route(route: str):
     return next(demo for demo in DEMOS if demo.route == route)
 
 
-def prepare_document(document, route: str) -> None:
+def prepare_document(document, route: str, *, measure_performance: bool = True) -> None:
     """Apply shared metadata, loading behavior, theme, and surface colors."""
     configure_document(document, demo_for_route(route))
     document.js_on_event(DocumentReady, CustomJS(code=REMOVE_LOADING_JS))
     document.theme = "light_minimal"
     for root in document.roots:
         match_background(root, colors.PAPER)
-    monitor_document(document, route).start(document)
+    if measure_performance:
+        monitor_document(document, route).start(document)
 
 
 def match_background(model, background: str) -> None:

--- a/apps/_common/performance.py
+++ b/apps/_common/performance.py
@@ -110,7 +110,7 @@ PUBLIC_CALLBACKS_BY_ROUTE = {
     ),
     "/wave-field": frozenset({"update_cross_section", "update_field", "update_palette"}),
 }
-PUBLIC_APP_ROUTES = frozenset(demo.route for demo in DEMOS)
+PUBLIC_APP_ROUTES = frozenset(demo.route for demo in DEMOS if demo.route != "/monitor")
 
 
 @dataclass(slots=True)

--- a/apps/monitor/__init__.py
+++ b/apps/monitor/__init__.py
@@ -215,7 +215,7 @@ def build_document(document, sampler: CoalescedSampler) -> None:
             spacing=16,
         )
     )
-    prepare_document(document, ROUTE)
+    prepare_document(document, ROUTE, measure_performance=False)
 
 
 def _stream_values(sample: MonitorSample) -> dict[str, np.ndarray]:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -158,6 +158,8 @@ def test_document_serialization_never_contains_aws_or_container_identifiers() ->
     history = document.select_one({"name": "monitor-history"})
     assert history is not None
     assert len(history.data["time"]) == 1
+    assert len(document.session_callbacks) == 1
+    assert document.session_callbacks[0].period == 2_000
     serialized = json.dumps(document.to_json(), default=str)
     assert ACCOUNT_ID not in serialized
     assert TASK_ARN not in serialized

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -104,6 +104,7 @@ def test_public_performance_exposes_only_catalog_and_allowlisted_labels() -> Non
     performance.record_callback(99.0, route="arn:aws:ecs:private", callback="advance", now=2.5)
     performance.record_event_loop(3.0, route="/market-monitor", now=2.1)
     performance.record_event_loop(5.0, route="/market-monitor", now=3.1)
+    performance.record_event_loop(55.0, route="/monitor", now=3.2)
     performance.record_event_loop(88.0, route="private-service-name", now=4.1)
 
     snapshot = performance.snapshot(now=5.0)
@@ -120,4 +121,5 @@ def test_public_performance_exposes_only_catalog_and_allowlisted_labels() -> Non
     serialized = json.dumps(asdict(snapshot))
     assert "private-runtime-label" not in serialized
     assert "private-service-name" not in serialized
+    assert '"/monitor"' not in serialized
     assert "arn:aws" not in serialized


### PR DESCRIPTION
## Summary

- keep the Monitor page's shared presentation setup without starting the ordinary per-session performance observer
- exclude `/monitor` from the public route allowlist as a second boundary
- verify each Monitor session has only its coalesced two-second refresh callback

This prevents the observer from appearing in its own event-loop table and avoids adding an extra one-second callback per Monitor viewer. Telemetry from every other public demo remains unchanged.

## Validation

- `PYTHON_GIL=0 uv run --locked pytest` (257 passed)
- Ruff formatting and lint checks
- Pyright
