### PR TITLE
Refine monitor rollout and fix airport viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ The public endpoints are:
 - `/`: generated gallery
 - `/404.html`: shared Bokeh 404 page
 - `/healthz`: runtime health and active Python GIL state
-- `/monitor`: public, sanitized view of the task or process serving the session,
-  including bounded timing summaries for public app and callback labels
+- `/monitor`: directly accessible, sanitized view of the task or process serving
+  the session, including anonymous activity counts and bounded timing summaries;
+  it is not listed in the gallery yet
 - `/assets/*`: shared site CSS
 - every route declared in `catalog.DEMOS`
 

--- a/apps/_common/__init__.py
+++ b/apps/_common/__init__.py
@@ -24,6 +24,7 @@ from catalog import DEMOS
 from presentation import SITE, configure_document
 
 from . import colors
+from .activity import PUBLIC_ACTIVITY
 from .callbacks import on_throttled_value as on_throttled_value
 from .performance import monitor_document
 from .streaming import PeriodicCoalescer as PeriodicCoalescer
@@ -62,6 +63,8 @@ def prepare_document(document, route: str, *, measure_performance: bool = True) 
     document.theme = "light_minimal"
     for root in document.roots:
         match_background(root, colors.PAPER)
+    if route != "/monitor":
+        PUBLIC_ACTIVITY.track_session(document)
     if measure_performance:
         monitor_document(document, route).start(document)
 

--- a/apps/_common/activity.py
+++ b/apps/_common/activity.py
@@ -1,0 +1,66 @@
+"""Count anonymous process-local activity for the public monitor."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from threading import Lock
+from time import monotonic
+from typing import Any
+from weakref import WeakSet, ref
+
+
+@dataclass(frozen=True, slots=True)
+class ActivitySnapshot:
+    """Anonymous activity totals from the current Python process."""
+
+    active_sessions: int
+    requests_per_minute: float
+
+
+class PublicActivity:
+    """Keep bounded numeric activity without retaining request details."""
+
+    def __init__(self, *, window_seconds: float = 60.0) -> None:
+        self._window_seconds = window_seconds
+        self._requests: deque[float] = deque()
+        self._sessions: WeakSet[Any] = WeakSet()
+        self._lock = Lock()
+
+    def record_request(self, *, now: float | None = None) -> None:
+        """Record only when a request happened, never what it contained."""
+        timestamp = monotonic() if now is None else now
+        with self._lock:
+            self._requests.append(timestamp)
+            self._prune_requests(timestamp)
+
+    def track_session(self, document: Any) -> None:
+        """Count a live Bokeh document until its session is destroyed."""
+        document_ref = ref(document)
+        with self._lock:
+            self._sessions.add(document)
+
+        def session_destroyed(_session_context: Any) -> None:
+            if tracked := document_ref():
+                with self._lock:
+                    self._sessions.discard(tracked)
+
+        document.on_session_destroyed(session_destroyed)
+
+    def snapshot(self, *, now: float | None = None) -> ActivitySnapshot:
+        """Return active sessions and a rolling one-minute request rate."""
+        timestamp = monotonic() if now is None else now
+        with self._lock:
+            self._prune_requests(timestamp)
+            return ActivitySnapshot(
+                active_sessions=len(self._sessions),
+                requests_per_minute=len(self._requests) * 60 / self._window_seconds,
+            )
+
+    def _prune_requests(self, now: float) -> None:
+        cutoff = now - self._window_seconds
+        while self._requests and self._requests[0] <= cutoff:
+            self._requests.popleft()
+
+
+PUBLIC_ACTIVITY = PublicActivity()

--- a/apps/airport_map.py
+++ b/apps/airport_map.py
@@ -9,7 +9,6 @@ import pandas as pd
 from bokeh.layouts import column
 from bokeh.models import (
     ColumnDataSource,
-    DataRange1d,
     Div,
     FactorRange,
     HoverTool,
@@ -113,7 +112,6 @@ def modify_document(document) -> None:
         data={**airport_data, "distance": np.zeros(len(airports), dtype=np.float32)},
         name="airport-map",
     )
-    viewport_source = ColumnDataSource(data={"x": [], "y": []}, name="airport-map-viewport")
     anchor_source = ColumnDataSource(data={"x": [], "y": [], "iata": []}, name="airport-anchor")
     route_source = ColumnDataSource(data={"xs": [], "ys": []}, name="airport-routes")
     ranking_source = ColumnDataSource(data={"label": [], "distance": []}, name="airport-neighbors")
@@ -129,8 +127,8 @@ def modify_document(document) -> None:
         styles={"padding": "14px", "background": WARM, "border-left": f"4px solid {GOLD}"}
     )
 
-    map_x_range = DataRange1d(range_padding=0)
-    map_y_range = DataRange1d(range_padding=0)
+    map_x_range = Range1d()
+    map_y_range = Range1d()
     map_title = Title()
     map_plot = figure(
         title=map_title,
@@ -155,11 +153,6 @@ def modify_document(document) -> None:
         line_width=1.3,
         name="airport-state-boundaries",
     )
-    viewport = map_plot.scatter(
-        "x", "y", source=viewport_source, visible=False, name="airport-map-viewport-renderer"
-    )
-    map_x_range.renderers = [viewport]
-    map_y_range.renderers = [viewport]
     map_plot.multi_line(
         xs="xs", ys="ys", source=route_source, color=CORAL, line_width=2.5, line_alpha=0.68
     )
@@ -321,10 +314,12 @@ def modify_document(document) -> None:
         region_y = region["y"].to_numpy(dtype=float)
         x_padding = max(float(np.ptp(region_x)) * 0.18, 70_000)
         y_padding = max(float(np.ptp(region_y)) * 0.18, 70_000)
-        viewport_source.data = {
-            "x": [float(np.min(region_x)) - x_padding, float(np.max(region_x)) + x_padding],
-            "y": [float(np.min(region_y)) - y_padding, float(np.max(region_y)) + y_padding],
-        }
+        x_start = float(np.min(region_x)) - x_padding
+        x_end = float(np.max(region_x)) + x_padding
+        y_start = float(np.min(region_y)) - y_padding
+        y_end = float(np.max(region_y)) + y_padding
+        map_x_range.update(start=x_start, end=x_end, reset_start=x_start, reset_end=x_end)
+        map_y_range.update(start=y_start, end=y_end, reset_start=y_start, reset_end=y_end)
         set_metric(count_card, f"{len(region):,}")
 
         if anchor.value in set(region["iata"]):

--- a/apps/monitor/__init__.py
+++ b/apps/monitor/__init__.py
@@ -56,6 +56,8 @@ def build_document(document, sampler: CoalescedSampler) -> None:
     memory_card = metric("Memory", "Sampling…", accent=TEAL)
     callbacks_card = metric("Python callbacks", "Sampling…", accent=GOLD)
     lag_card = metric("Event-loop lag", "Sampling…", accent=VIOLET)
+    sessions_card = metric("Active demo sessions", "Sampling…", accent=TEAL)
+    requests_card = metric("Page requests", "Sampling…", accent=CORAL)
     callback_apps = _table_panel("Callback latency by app", name="monitor-callback-apps")
     event_loop_apps = _table_panel("Event-loop lag by app", name="monitor-event-loop-apps")
     slowest_callbacks = _table_panel("Slowest callbacks", name="monitor-slowest-callbacks")
@@ -146,7 +148,9 @@ def build_document(document, sampler: CoalescedSampler) -> None:
             return
         state["generation"] = sample.generation
         source.stream(cast(Any, _stream_values(sample)), rollover=HISTORY_POINTS)
-        _update_cards(sample, cpu_card, memory_card, callbacks_card, lag_card)
+        _update_cards(
+            sample, cpu_card, memory_card, sessions_card, requests_card, callbacks_card, lag_card
+        )
         _update_timing_tables(sample, callback_apps, event_loop_apps, slowest_callbacks)
         if sample.source_label != state["source_label"]:
             status.text = _source_status(sample)
@@ -159,8 +163,10 @@ def build_document(document, sampler: CoalescedSampler) -> None:
         text=(
             "<h2>What this page measures</h2>"
             "<p>In production, CPU, memory, and network describe the ECS task handling this session. "
-            "Callback timing and event-loop lag come from that task's Python process. This is not a "
-            "service-wide view, so another visitor may see a different server.</p>"
+            "Active sessions, page requests, callback timing, and event-loop lag come from that task's Python "
+            "process. Sessions are open Bokeh documents, not unique people. Monitor and health-check "
+            "requests are excluded. This is not a service-wide view, so another visitor may see a different "
+            "server.</p>"
         ),
         styles={
             "background": WARM,
@@ -178,7 +184,8 @@ def build_document(document, sampler: CoalescedSampler) -> None:
             "fixed list in the source code. The page does not send task metadata, AWS identifiers, "
             "credentials, logs, IP addresses, request headers, referrers, or query strings. The server reads "
             "ECS stats at most once every two seconds and shares each reading among the monitor sessions on "
-            "that process.</p>"
+            "that process. The activity counters keep only request timestamps and the number of live Bokeh "
+            "documents.</p>"
         ),
         styles={
             "border-left": f"3px solid {GOLD}",
@@ -194,7 +201,13 @@ def build_document(document, sampler: CoalescedSampler) -> None:
         column(
             status,
             metric_row(
-                cpu_card, memory_card, callbacks_card, lag_card, sizing_mode="stretch_width"
+                cpu_card,
+                memory_card,
+                sessions_card,
+                requests_card,
+                callbacks_card,
+                lag_card,
+                sizing_mode="stretch_width",
             ),
             explanation,
             responsive_row(utilization, latency, sizing_mode="stretch_width"),
@@ -237,7 +250,7 @@ def _stream_values(sample: MonitorSample) -> dict[str, np.ndarray]:
     }
 
 
-def _update_cards(sample: MonitorSample, cpu, memory, callbacks, lag) -> None:
+def _update_cards(sample: MonitorSample, cpu, memory, sessions, requests, callbacks, lag) -> None:
     if sample.scope == "task":
         cpu_label = "Current task CPU"
         memory_label = "Current task memory"
@@ -253,6 +266,10 @@ def _update_cards(sample: MonitorSample, cpu, memory, callbacks, lag) -> None:
     else:
         memory_value = _mib(sample.memory_bytes)
     set_metric(memory, memory_value, label=memory_label)
+    set_metric(sessions, str(sample.active_sessions), label="Current process active sessions")
+    set_metric(
+        requests, f"{sample.requests_per_minute:.0f} / min", label="Current process page requests"
+    )
     set_metric(callbacks, f"{sample.callback_rate:.1f} / s", label="Current process callbacks")
     set_metric(lag, _milliseconds(sample.event_loop_p95_ms), label="Current process loop-lag p95")
 

--- a/apps/monitor/metrics.py
+++ b/apps/monitor/metrics.py
@@ -17,6 +17,7 @@ from typing import Any, Protocol
 from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
+from apps._common.activity import PUBLIC_ACTIVITY, PublicActivity
 from apps._common.performance import (
     PUBLIC_PERFORMANCE,
     AppTiming,
@@ -60,6 +61,8 @@ class MonitorSample:
     memory_percent: float | None
     rx_bytes_per_second: float | None
     tx_bytes_per_second: float | None
+    active_sessions: int
+    requests_per_minute: float
     callback_rate: float
     callback_p95_ms: float | None
     event_loop_p95_ms: float | None
@@ -322,11 +325,13 @@ class CoalescedSampler:
         adapter: MetricsAdapter,
         *,
         performance: PublicPerformance = PUBLIC_PERFORMANCE,
+        activity: PublicActivity = PUBLIC_ACTIVITY,
         interval_seconds: float = SAMPLE_INTERVAL_SECONDS,
         fallback: MetricsAdapter | None = None,
     ) -> None:
         self._adapter = adapter
         self._performance = performance
+        self._activity = activity
         self._interval_seconds = interval_seconds
         self._fallback = fallback or DeterministicAdapter(
             source_label="Deterministic fallback · live source unavailable"
@@ -350,8 +355,13 @@ class CoalescedSampler:
                 return self._last_sample
             system = self._read_system(sampled_at)
             performance = self._performance.snapshot(now=sampled_at)
+            activity = self._activity.snapshot(now=sampled_at)
             if system.deterministic:
                 performance = _deterministic_performance(self._generation)
+                active_sessions, requests_per_minute = _deterministic_activity(self._generation)
+            else:
+                active_sessions = activity.active_sessions
+                requests_per_minute = activity.requests_per_minute
             self._generation += 1
             self._last_sampled_at = sampled_at
             self._last_sample = MonitorSample(
@@ -365,6 +375,8 @@ class CoalescedSampler:
                 memory_percent=system.memory_percent,
                 rx_bytes_per_second=system.rx_bytes_per_second,
                 tx_bytes_per_second=system.tx_bytes_per_second,
+                active_sessions=active_sessions,
+                requests_per_minute=requests_per_minute,
                 callback_rate=performance.callback_count / performance.window_seconds,
                 callback_p95_ms=performance.callback_p95_ms,
                 event_loop_p95_ms=performance.event_loop_p95_ms,
@@ -450,3 +462,8 @@ def _deterministic_performance(index: int) -> PerformanceSnapshot:
         event_loop_by_app=event_loop_by_app,
         slowest_callbacks=slowest_callbacks,
     )
+
+
+def _deterministic_activity(index: int) -> tuple[int, float]:
+    phase = index / 6
+    return 5 + round(2 * (1 + math.sin(phase))), 18 + 7 * (1 + math.sin(phase * 1.3))

--- a/asgi.py
+++ b/asgi.py
@@ -12,7 +12,8 @@ from urllib.parse import parse_qs
 
 from bokeh.server.asgi import BokehASGI
 
-from catalog import load_applications
+from apps._common.activity import PUBLIC_ACTIVITY, PublicActivity
+from catalog import DEMOS, load_applications
 from presentation import ROOT, render_index
 
 os.environ.setdefault("BOKEH_RESOURCES", "cdn")
@@ -38,12 +39,18 @@ LEGACY_DEMO_ROUTES = frozenset(
         "/weather",
     }
 )
+PUBLIC_PAGE_ROUTES = frozenset(
+    {"/", "/index.html", *LEGACY_DEMO_ROUTES, *(demo.route for demo in DEMOS if demo.listed)}
+)
 
 
 class DemoApplication:
-    def __init__(self, bokeh: BokehASGI, runtime_health: bytes) -> None:
+    def __init__(
+        self, bokeh: BokehASGI, runtime_health: bytes, *, activity: PublicActivity = PUBLIC_ACTIVITY
+    ) -> None:
         self._bokeh = bokeh
         self._runtime_health = runtime_health
+        self._activity = activity
         self._index = render_index()
         self._legacy_index = render_index(show_legacy_notice=True)
         self._not_found = (ASSET_ROOT / "404.html").read_bytes()
@@ -51,6 +58,8 @@ class DemoApplication:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope_type = scope["type"]
         path = scope.get("path", "/")
+        if scope_type == "http" and _counts_as_public_request(path):
+            self._activity.record_request()
 
         if scope_type == "lifespan":
             await self._bokeh(scope, receive, send)
@@ -174,6 +183,11 @@ def create_application() -> DemoApplication:
     applications = load_applications()
     bokeh = BokehASGI(applications, redirect_root=False, extra_websocket_origins=origins)
     return DemoApplication(bokeh, _runtime_health())
+
+
+def _counts_as_public_request(path: str) -> bool:
+    """Count page entry requests without monitor, health, or asset traffic."""
+    return path in PUBLIC_PAGE_ROUTES
 
 
 def _runtime_health(

--- a/catalog.py
+++ b/catalog.py
@@ -32,6 +32,7 @@ class Demo:
     tags: tuple[str, ...]
     accent: str
     preview: str
+    listed: bool = True
 
     @property
     def source_url(self) -> str:
@@ -66,6 +67,7 @@ def load_manifest() -> tuple[Demo, ...]:
 
 
 DEMOS = load_manifest()
+LISTED_DEMOS = tuple(demo for demo in DEMOS if demo.listed)
 
 
 def load_applications() -> Mapping[str, Callable[[Document], None]]:

--- a/catalog.toml
+++ b/catalog.toml
@@ -10,6 +10,7 @@ runtime = "Python / ASGI"
 tags = ["ECS task stats", "streaming", "event-loop lag", "privacy boundary", "live data"]
 accent = "coral"
 preview = "monitor-preview.jpg"
+listed = false
 
 [[demos]]
 route = "/mobility"

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -10,13 +10,17 @@ to describe the whole ECS service.
 | --- | --- | --- |
 | CPU and memory | Current serving ECS task | Current Python process |
 | Network receive/send rate | Current serving ECS task | Local container when available |
+| Active Bokeh sessions | Current Python process | Current Python process |
+| Page requests per minute | Current Python process | Current Python process |
 | Callback rate and p95 duration | Current Python process | Current Python process |
 | Callback latency by app and slowest named callbacks | Current Python process | Current Python process |
 | Event-loop lag p95 and app breakdown | Current Python process | Current Python process |
 
-Another ECS task may serve another visitor. Service-wide task count, request
-rate, errors, and load-balancer measurements remain private operational data and
-are not inferred or shown.
+Active sessions are open Bokeh documents, not unique people. The request rate
+counts gallery and demo page entries, excluding assets, health checks, and the
+monitor's own traffic. Another ECS task may serve another visitor. Service-wide
+task count, request rate, errors, and load-balancer measurements remain private
+operational data and are not inferred or shown.
 
 ## Production source
 
@@ -44,13 +48,15 @@ values when changing task size.
 The Bokeh document contains timestamps, numeric measurements, fixed generic
 source labels, public routes already listed in the site catalog, and callback
 identifiers from an explicit allowlist of functions in this public repository.
+The request counter retains only bounded timestamps, not request paths or
+contents. The session counter keeps weak references to live Bokeh documents.
 An unknown route or callback label is discarded before it can enter a public
 snapshot. The document contains no AWS account IDs, ARNs, resource names,
 endpoint URI, credentials, task/container IDs, raw logs, source IPs, user
 agents, referrers, request headers, or query strings.
 
 Existing callback-duration and event-loop-lag instrumentation feeds bounded
-60-second process aggregates. Sessions and log identity are always discarded.
+60-second process aggregates. Session and log identity are always discarded.
 Only catalog routes and explicitly allowlisted code-level callback names can be
 retained for the three performance tables. Event-loop observations are
 coalesced to at most one per process-wide one-second bucket for the headline

--- a/presentation.py
+++ b/presentation.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from bokeh.document import Document
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from catalog import DEMOS, Demo
+from catalog import LISTED_DEMOS, Demo
 
 ROOT = Path(__file__).parent
 SITE = ROOT / "site"
@@ -27,7 +27,7 @@ APP_TEMPLATE = (SITE / "application.html.jinja").read_text()
 
 def render_index(*, show_legacy_notice: bool = False) -> bytes:
     return INDEX_TEMPLATE.render(
-        demos=DEMOS,
+        demos=LISTED_DEMOS,
         site_header=SITE_HEADER,
         site_footer=SITE_FOOTER,
         show_legacy_notice=show_legacy_notice,

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,0 +1,24 @@
+"""Test anonymous process-local activity measurements."""
+
+from __future__ import annotations
+
+from bokeh.document import Document
+
+from apps._common.activity import PublicActivity
+
+
+def test_activity_counts_only_live_sessions_and_recent_request_times() -> None:
+    activity = PublicActivity(window_seconds=60)
+    first = Document()
+    second = Document()
+    activity.track_session(first)
+    activity.track_session(second)
+    activity.record_request(now=40)
+    activity.record_request(now=70)
+
+    snapshot = activity.snapshot(now=110)
+
+    assert snapshot.active_sessions == 2
+    assert snapshot.requests_per_minute == 1
+    next(iter(first.session_destroyed_callbacks))(None)
+    assert activity.snapshot(now=110).active_sessions == 1

--- a/tests/test_airport_map.py
+++ b/tests/test_airport_map.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 from bokeh.document import Document
-from bokeh.models import ColumnDataSource, DataRange1d, HoverTool, Select, TileRenderer
+from bokeh.models import ColumnDataSource, HoverTool, Range1d, Select, TileRenderer
 
 from catalog import load_applications
 
@@ -22,7 +22,6 @@ def test_airport_map_uses_tiles_and_links_the_selected_airport() -> None:
         select for select in document.select({"type": Select}) if select.title == "Anchor airport"
     )
     airports = document.select_one({"type": ColumnDataSource, "name": "airport-map"})
-    viewport = document.select_one({"type": ColumnDataSource, "name": "airport-map-viewport"})
     ranking = document.select_one({"type": ColumnDataSource, "name": "airport-neighbors"})
     access = document.select_one({"type": ColumnDataSource, "name": "airport-access-curve"})
     map_plot = document.select_one({"name": "airport-map-plot"})
@@ -30,14 +29,8 @@ def test_airport_map_uses_tiles_and_links_the_selected_airport() -> None:
     access_plot = document.select_one({"name": "airport-access-plot"})
     state_boundaries = document.select_one({"name": "airport-state-boundaries"})
     assert map_plot.match_aspect
-    assert isinstance(map_plot.x_range, DataRange1d)
-    assert isinstance(map_plot.y_range, DataRange1d)
-    assert map_plot.x_range.renderers == [
-        document.select_one({"name": "airport-map-viewport-renderer"})
-    ]
-    assert map_plot.y_range.renderers == [
-        document.select_one({"name": "airport-map-viewport-renderer"})
-    ]
+    assert isinstance(map_plot.x_range, Range1d)
+    assert isinstance(map_plot.y_range, Range1d)
     assert state_boundaries.glyph.line_width == 1.3
     assert state_boundaries.glyph.line_alpha == 0.55
     assert ranking_plot.toolbar.tools == []
@@ -51,7 +44,7 @@ def test_airport_map_uses_tiles_and_links_the_selected_airport() -> None:
     airport_count = len(airports.data["iata"])
     assert airport_count > 500
     assert (np.diff(access.data["count"]) >= 0).all()
-    previous_view = dict(viewport.data)
+    previous_view = (map_plot.x_range.start, map_plot.x_range.end)
     access_updates = []
     access.on_change("data", lambda _attr, _old, new: access_updates.append(new))
     state.value = "CA"
@@ -59,7 +52,9 @@ def test_airport_map_uses_tiles_and_links_the_selected_airport() -> None:
     assert len(airports.data["iata"]) == airport_count
     assert any(value != "CA" for value in airports.data["state"])
     assert len(ranking.data["distance"]) == 6
-    assert viewport.data != previous_view
+    assert (map_plot.x_range.start, map_plot.x_range.end) != previous_view
+    assert map_plot.x_range.reset_start == map_plot.x_range.start
+    assert map_plot.x_range.reset_end == map_plot.x_range.end
     adjacent_index = next(
         index for index, value in enumerate(airports.data["state"]) if value == "NV"
     )

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import sys
 
-from asgi import LEGACY_DEMO_ROUTES, _runtime_health, application
+from asgi import LEGACY_DEMO_ROUTES, _counts_as_public_request, _runtime_health, application
 from catalog import DEMOS
 
 
@@ -78,6 +78,16 @@ def test_health_reports_an_unexpected_enabled_gil_as_degraded() -> None:
         "reason": "python_gil_enabled",
         "python_gil": "enabled",
     }
+
+
+def test_public_request_counter_excludes_monitor_and_health_traffic() -> None:
+    assert _counts_as_public_request("/")
+    assert _counts_as_public_request("/airport-access")
+    assert not _counts_as_public_request("/assets/site.css")
+    assert not _counts_as_public_request("/favicon.ico")
+    assert not _counts_as_public_request("/healthz")
+    assert not _counts_as_public_request("/monitor")
+    assert not _counts_as_public_request("/monitor/ws")
 
 
 def test_index_head_has_no_body() -> None:

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -20,7 +20,7 @@ from bokeh.models import (
 )
 
 import presentation
-from catalog import DEMOS, load_applications
+from catalog import DEMOS, LISTED_DEMOS, load_applications
 from presentation import APP_TEMPLATE, SITE_FOOTER, SITE_HEADER, configure_document, render_index
 
 
@@ -84,7 +84,7 @@ def test_landing_page_comes_from_catalog() -> None:
     assert "runtime-section" not in html
     assert "uv run --locked uvicorn asgi:application" in html
     assert 'class="demo-card featured' not in html
-    for demo in DEMOS:
+    for demo in LISTED_DEMOS:
         assert f'href="{demo.route}"' in html
         assert demo.title in html
         assert f"/assets/{demo.preview}?v=11" in html
@@ -100,8 +100,8 @@ def test_landing_page_legacy_notice_is_opt_in() -> None:
 
 
 def test_landing_page_escapes_catalog_content(monkeypatch) -> None:
-    unsafe = replace(DEMOS[0], title="<script>alert('bad')</script>")
-    monkeypatch.setattr(presentation, "DEMOS", (unsafe,))
+    unsafe = replace(LISTED_DEMOS[0], title="<script>alert('bad')</script>")
+    monkeypatch.setattr(presentation, "LISTED_DEMOS", (unsafe,))
 
     html = render_index().decode()
 


### PR DESCRIPTION
## Summary

- keep `/monitor` directly reachable while leaving it out of the public gallery
- add anonymous current-process active-session and page-request measurements; retain no request details and exclude monitor, health, and asset traffic
- update Airport Access with explicit map ranges so selecting a state reliably moves the viewport and Reset returns to that state
- document the measurement scope and privacy boundary

No AWS or infra changes are needed.

## Validation

- `uv run --locked pytest -q` (259 passed)
- `uv run --locked ruff check apps tests asgi.py catalog.py presentation.py`
- `uv run --locked pyright`
- local browser: `/monitor` loads directly, its new cards render, and `/` has no monitor card or link
