### PR TITLE
Keep monitor traffic excluded when listed

### DIFF
--- a/asgi.py
+++ b/asgi.py
@@ -40,7 +40,12 @@ LEGACY_DEMO_ROUTES = frozenset(
     }
 )
 PUBLIC_PAGE_ROUTES = frozenset(
-    {"/", "/index.html", *LEGACY_DEMO_ROUTES, *(demo.route for demo in DEMOS if demo.listed)}
+    {
+        "/",
+        "/index.html",
+        *LEGACY_DEMO_ROUTES,
+        *(demo.route for demo in DEMOS if demo.route != "/monitor"),
+    }
 )
 
 


### PR DESCRIPTION
## Summary

Keep the monitor route explicitly out of the anonymous page-request counter, independent of whether its gallery card is listed. This preserves the self-observation boundary if `catalog.toml` later changes `listed` to `true`.

## Validation

- `uv run --locked pytest -q tests/test_asgi.py tests/test_monitor.py` (16 passed)
- `uv run --locked ruff check asgi.py tests/test_asgi.py`
- `uv run --locked pyright`
