### PR TITLE
Add catalog sitemap and crawler policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The public endpoints are:
 - `/`: generated gallery
 - `/404.html`: shared Bokeh 404 page
 - `/healthz`: runtime health and active Python GIL state
+- `/robots.txt`: crawler policy and sitemap discovery
+- `/sitemap.xml`: homepage and listed demo routes generated from the catalog
 - `/monitor`: directly accessible, sanitized view of the task or process serving
   the session, including anonymous activity counts and bounded timing summaries;
   it is not listed in the gallery yet

--- a/asgi.py
+++ b/asgi.py
@@ -9,11 +9,12 @@ import sys
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 from urllib.parse import parse_qs
+from xml.sax.saxutils import escape
 
 from bokeh.server.asgi import BokehASGI
 
 from apps._common.activity import PUBLIC_ACTIVITY, PublicActivity
-from catalog import DEMOS, load_applications
+from catalog import DEMOS, LISTED_DEMOS, load_applications
 from presentation import ROOT, render_index
 
 os.environ.setdefault("BOKEH_RESOURCES", "cdn")
@@ -26,6 +27,7 @@ type Scope = dict[str, Any]
 type Send = Callable[[Message], Awaitable[None]]
 
 ASSET_ROOT = ROOT / "site"
+SITE_ORIGIN = "https://demo.bokeh.org"
 LEGACY_DEMO_ROUTES = frozenset(
     {
         "/crossfilter",
@@ -39,6 +41,21 @@ LEGACY_DEMO_ROUTES = frozenset(
         "/weather",
     }
 )
+
+
+def _render_sitemap() -> bytes:
+    locations = (f"{SITE_ORIGIN}/", *(f"{SITE_ORIGIN}{demo.route}" for demo in LISTED_DEMOS))
+    urls = "\n".join(f"  <url><loc>{escape(location)}</loc></url>" for location in locations)
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        f"{urls}\n"
+        "</urlset>\n"
+    ).encode()
+
+
+SITEMAP = _render_sitemap()
+ROBOTS = (f"User-agent: *\nAllow: /\n\nSitemap: {SITE_ORIGIN}/sitemap.xml\n").encode()
 PUBLIC_PAGE_ROUTES = frozenset(
     {
         "/",
@@ -74,6 +91,22 @@ class DemoApplication:
             query = parse_qs(scope.get("query_string", b"").decode())
             index = self._legacy_index if "legacy-demo" in query else self._index
             await self._response(scope, send, index, "text/html; charset=utf-8")
+        elif scope_type == "http" and path == "/robots.txt":
+            await self._response(
+                scope,
+                send,
+                ROBOTS,
+                "text/plain; charset=utf-8",
+                cache_control="public, max-age=3600",
+            )
+        elif scope_type == "http" and path == "/sitemap.xml":
+            await self._response(
+                scope,
+                send,
+                SITEMAP,
+                "application/xml; charset=utf-8",
+                cache_control="public, max-age=3600",
+            )
         elif scope_type == "http" and path == "/healthz":
             await self._response(
                 scope,

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+from xml.etree import ElementTree
 
-from asgi import LEGACY_DEMO_ROUTES, _counts_as_public_request, _runtime_health, application
-from catalog import DEMOS
+from asgi import (
+    LEGACY_DEMO_ROUTES,
+    SITE_ORIGIN,
+    _counts_as_public_request,
+    _runtime_health,
+    application,
+)
+from catalog import DEMOS, LISTED_DEMOS
 
 
 async def request(path: str, *, method: str = "GET") -> tuple[int, dict[str, str], bytes]:
@@ -86,6 +93,8 @@ def test_public_request_counter_excludes_monitor_and_health_traffic() -> None:
     assert not _counts_as_public_request("/assets/site.css")
     assert not _counts_as_public_request("/favicon.ico")
     assert not _counts_as_public_request("/healthz")
+    assert not _counts_as_public_request("/robots.txt")
+    assert not _counts_as_public_request("/sitemap.xml")
     assert not _counts_as_public_request("/monitor")
     assert not _counts_as_public_request("/monitor/ws")
 
@@ -114,6 +123,38 @@ def test_favicon() -> None:
     assert status == 200
     assert headers["content-type"] == "image/svg+xml"
     assert b'<svg id="Layer_1"' in body
+
+
+def test_robots_points_to_the_catalog_sitemap_without_advertising_monitor() -> None:
+    status, headers, body = asyncio.run(request("/robots.txt"))
+
+    assert status == 200
+    assert headers["content-type"] == "text/plain; charset=utf-8"
+    assert headers["cache-control"] == "public, max-age=3600"
+    assert body.decode().splitlines() == [
+        "User-agent: *",
+        "Allow: /",
+        "",
+        f"Sitemap: {SITE_ORIGIN}/sitemap.xml",
+    ]
+    assert "/monitor" not in body.decode()
+
+
+def test_sitemap_contains_only_the_homepage_and_listed_catalog_demos() -> None:
+    status, headers, body = asyncio.run(request("/sitemap.xml"))
+
+    assert status == 200
+    assert headers["content-type"] == "application/xml; charset=utf-8"
+    assert headers["cache-control"] == "public, max-age=3600"
+    root = ElementTree.fromstring(body)
+    namespace = {"sitemap": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    locations = [element.text for element in root.findall("sitemap:url/sitemap:loc", namespace)]
+    assert locations == [
+        f"{SITE_ORIGIN}/",
+        *(f"{SITE_ORIGIN}{demo.route}" for demo in LISTED_DEMOS),
+    ]
+    assert f"{SITE_ORIGIN}/monitor" not in locations
+    assert all(f"{SITE_ORIGIN}{route}" not in locations for route in LEGACY_DEMO_ROUTES)
 
 
 def test_every_catalog_preview_is_a_served_image() -> None:


### PR DESCRIPTION
## Summary
- serve a catalog-derived sitemap containing the homepage and listed demos
- serve robots.txt with sitemap discovery
- keep the unlisted monitor and legacy redirect routes out of the sitemap

## Validation
- 261 pytest tests passed
- all pre-commit hooks passed