### PR TITLE
Add a service-wide public monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,8 @@ The public endpoints are:
 - `/robots.txt`: crawler policy and sitemap discovery
 - `/sitemap.xml`: homepage and listed demo routes generated from the catalog
 - `/.well-known/security.txt`: private vulnerability-reporting contact and policy
-- `/monitor`: directly accessible, sanitized view of the task or process serving
-  the session, including anonymous activity counts and bounded timing summaries;
-  it is not listed in the gallery yet
+- `/monitor`: directly accessible, sanitized view of the whole demo service and
+  the task serving the session; it is not listed in the gallery yet
 - `/assets/*`: shared site CSS
 - every route declared in `catalog.DEMOS`
 
@@ -132,9 +131,9 @@ uv run --locked uvicorn asgi:application
 
 Open `http://127.0.0.1:8000`.
 
-The monitor uses real current-process CPU and memory measurements outside ECS.
-For deterministic screenshots or UI development, run it with clearly labeled
-demonstration values:
+Outside ECS, the monitor uses real current-process measurements and an in-memory
+service registry. For deterministic screenshots or UI development, run it with
+three clearly labeled simulated task reports:
 
 ```sh
 DEMO_MONITOR_SOURCE=deterministic uv run --locked uvicorn asgi:application
@@ -202,4 +201,5 @@ AWS demo stack README.
 See [Production operations](docs/operations.md) for rollout verification,
 CloudWatch callback timings, event-loop lag queries, and smoke-test guidance.
 The [monitor data-source and privacy note](docs/monitor.md) documents its public
-numeric contract, scope, local behavior, and cost boundary.
+contract, DynamoDB exchange, measurement scopes, local behavior, deployment
+order, and cost boundary.

--- a/apps/_common/performance.py
+++ b/apps/_common/performance.py
@@ -40,6 +40,7 @@ PUBLIC_CALLBACK_SAMPLE_LIMIT = 4096
 PUBLIC_EVENT_LOOP_SAMPLE_LIMIT = 1024
 PUBLIC_APP_ROW_LIMIT = 8
 PUBLIC_CALLBACK_ROW_LIMIT = 12
+PUBLIC_LATENCY_BUCKETS_MS = (0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0)
 
 # Callback labels are code identifiers from this public repository, but they are
 # still explicitly allowlisted so an accidental runtime label can never become
@@ -149,6 +150,7 @@ class AppTiming:
     count: int
     p95_ms: float
     max_ms: float
+    histogram: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,6 +162,7 @@ class CallbackTiming:
     count: int
     p95_ms: float
     max_ms: float
+    histogram: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -172,6 +175,8 @@ class PerformanceSnapshot:
     callback_max_ms: float | None
     event_loop_p95_ms: float | None
     event_loop_max_ms: float | None
+    callback_histogram: tuple[int, ...] = ()
+    event_loop_histogram: tuple[int, ...] = ()
     callbacks_by_app: tuple[AppTiming, ...] = ()
     event_loop_by_app: tuple[AppTiming, ...] = ()
     slowest_callbacks: tuple[CallbackTiming, ...] = ()
@@ -244,6 +249,8 @@ class PublicPerformance:
             callback_max_ms=max(callbacks, default=None),
             event_loop_p95_ms=self._percentile(event_loop),
             event_loop_max_ms=max(event_loop, default=None),
+            callback_histogram=latency_histogram(callbacks),
+            event_loop_histogram=latency_histogram(event_loop),
             callbacks_by_app=callbacks_by_app,
             event_loop_by_app=event_loop_by_app,
             slowest_callbacks=slowest_callbacks,
@@ -282,6 +289,7 @@ class PublicPerformance:
                 count=len(values),
                 p95_ms=cls._percentile(values) or 0.0,
                 max_ms=max(values),
+                histogram=latency_histogram(values),
             )
             for app, values in grouped.items()
         )
@@ -304,6 +312,7 @@ class PublicPerformance:
                 count=len(values),
                 p95_ms=cls._percentile(values) or 0.0,
                 max_ms=max(values),
+                histogram=latency_histogram(values),
             )
             for (app, callback), values in grouped.items()
         )
@@ -317,6 +326,37 @@ class PublicPerformance:
             return None
         ordered = sorted(values)
         return ordered[max(0, ceil(0.95 * len(ordered)) - 1)]
+
+
+def latency_histogram(values: list[float]) -> tuple[int, ...]:
+    """Return mergeable counts using fixed, public millisecond boundaries."""
+    counts = [0] * (len(PUBLIC_LATENCY_BUCKETS_MS) + 1)
+    for value in values:
+        for index, boundary in enumerate(PUBLIC_LATENCY_BUCKETS_MS):
+            if value <= boundary:
+                counts[index] += 1
+                break
+        else:
+            counts[-1] += 1
+    return tuple(counts)
+
+
+def histogram_percentile(
+    histogram: tuple[int, ...], *, percentile: float = 0.95, maximum: float | None = None
+) -> float | None:
+    """Estimate a percentile from merged fixed buckets."""
+    total = sum(histogram)
+    if total <= 0:
+        return None
+    target = max(1, ceil(percentile * total))
+    cumulative = 0
+    for index, count in enumerate(histogram):
+        cumulative += count
+        if cumulative >= target:
+            if index < len(PUBLIC_LATENCY_BUCKETS_MS):
+                return PUBLIC_LATENCY_BUCKETS_MS[index]
+            return maximum if maximum is not None else PUBLIC_LATENCY_BUCKETS_MS[-1]
+    return maximum
 
 
 PUBLIC_PERFORMANCE = PublicPerformance()

--- a/apps/monitor/__init__.py
+++ b/apps/monitor/__init__.py
@@ -1,4 +1,4 @@
-"""Show a privacy-bounded view of the server currently serving this session."""
+"""Show a privacy-bounded view of the demo service and serving task."""
 
 from __future__ import annotations
 
@@ -21,19 +21,23 @@ from apps._common import (
 from apps._common.colors import CORAL, GOLD, MUTED, PLUM, TEAL, VIOLET, WARM
 from apps._common.performance import AppTiming, CallbackTiming
 
+from .global_metrics import ServiceMonitor, ServiceSample, create_service_monitor
 from .metrics import CoalescedSampler, MonitorSample, create_adapter
 
 ROUTE = "/monitor"
 HISTORY_POINTS = 90
 SAMPLER = CoalescedSampler(create_adapter())
+SERVICE_MONITOR = create_service_monitor(SAMPLER)
 
 
 def modify_document(document) -> None:
     """Build the public monitor using the process-wide coalesced sampler."""
-    build_document(document, SAMPLER)
+    build_document(document, SAMPLER, SERVICE_MONITOR)
 
 
-def build_document(document, sampler: CoalescedSampler) -> None:
+def build_document(
+    document, sampler: CoalescedSampler, service_monitor: ServiceMonitor | None = None
+) -> None:
     """Build a monitor document around an injectable sampler for tests."""
     source = ColumnDataSource(
         data={
@@ -47,11 +51,24 @@ def build_document(document, sampler: CoalescedSampler) -> None:
         },
         name="monitor-history",
     )
-    status = Div(
-        name="monitor-source",
+    task_status = Div(
+        name="monitor-task-source",
         sizing_mode="stretch_width",
         stylesheets=[".bk-clearfix { display: block; width: 100%; }"],
     )
+    service_status = Div(
+        name="monitor-service-source",
+        sizing_mode="stretch_width",
+        stylesheets=[".bk-clearfix { display: block; width: 100%; }"],
+    )
+    tasks_card = metric("Reporting tasks", "Warming up", accent=GOLD)
+    service_sessions_card = metric("Open sessions", "Warming up", accent=TEAL)
+    service_pages_card = metric("Page entries", "Warming up", accent=CORAL)
+    service_cpu_card = metric("Combined CPU", "Warming up", accent=CORAL)
+    service_memory_card = metric("Combined memory", "Warming up", accent=TEAL)
+    service_network_card = metric("Combined network", "Warming up", accent=VIOLET)
+    service_callbacks_card = metric("Python callbacks", "Warming up", accent=GOLD)
+    service_lag_card = metric("Event-loop lag", "Warming up", accent=VIOLET)
     cpu_card = metric("CPU", "Sampling…", accent=CORAL)
     memory_card = metric("Memory", "Sampling…", accent=TEAL)
     callbacks_card = metric("Python callbacks", "Sampling…", accent=GOLD)
@@ -140,33 +157,61 @@ def build_document(document, sampler: CoalescedSampler) -> None:
     network.legend.click_policy = "mute"
     style_figure(network)
 
-    state: dict[str, Any] = {"generation": None, "source_label": None}
+    state: dict[str, Any] = {
+        "task_generation": None,
+        "task_source_label": None,
+        "service_generation": None,
+    }
 
     def refresh() -> None:
-        sample = sampler.sample()
-        if sample.generation == state["generation"]:
-            return
-        state["generation"] = sample.generation
-        source.stream(cast(Any, _stream_values(sample)), rollover=HISTORY_POINTS)
-        _update_cards(
-            sample, cpu_card, memory_card, sessions_card, requests_card, callbacks_card, lag_card
-        )
-        _update_timing_tables(sample, callback_apps, event_loop_apps, slowest_callbacks)
-        if sample.source_label != state["source_label"]:
-            status.text = _source_status(sample)
-            state["source_label"] = sample.source_label
+        task_sample = sampler.sample()
+        if task_sample.generation != state["task_generation"]:
+            state["task_generation"] = task_sample.generation
+            source.stream(cast(Any, _stream_values(task_sample)), rollover=HISTORY_POINTS)
+            _update_cards(
+                task_sample,
+                cpu_card,
+                memory_card,
+                sessions_card,
+                requests_card,
+                callbacks_card,
+                lag_card,
+            )
+            if task_sample.source_label != state["task_source_label"]:
+                task_status.text = _source_status(task_sample)
+                state["task_source_label"] = task_sample.source_label
+        if service_monitor is not None:
+            service_sample = service_monitor.sample()
+            if service_sample.generation != state["service_generation"]:
+                state["service_generation"] = service_sample.generation
+                service_status.text = _service_status(service_sample)
+                _update_service_cards(
+                    service_sample,
+                    tasks_card,
+                    service_sessions_card,
+                    service_pages_card,
+                    service_cpu_card,
+                    service_memory_card,
+                    service_network_card,
+                    service_callbacks_card,
+                    service_lag_card,
+                )
+                _update_timing_tables(
+                    service_sample, callback_apps, event_loop_apps, slowest_callbacks
+                )
+        elif task_sample.generation == state["task_generation"]:
+            _update_timing_tables(task_sample, callback_apps, event_loop_apps, slowest_callbacks)
 
     refresh()
     document.add_periodic_callback(refresh, 2_000)
 
     explanation = Div(
         text=(
-            "<h2>What this page measures</h2>"
-            "<p>In production, CPU, memory, and network describe the ECS task handling this session. "
-            "Active sessions, page requests, callback timing, and event-loop lag come from that task's Python "
-            "process. Sessions are open Bokeh documents, not unique people. Monitor and health-check "
-            "requests are excluded. This is not a service-wide view, so another visitor may see a different "
-            "server.</p>"
+            "<h2>How to read this page</h2>"
+            "<p>The first section combines fresh reports from the running demo tasks. An open session is a "
+            "Bokeh document, not a unique person. Page entries count visits to demo pages, not static files "
+            "served by Cloudflare. The lower charts describe only the task handling this monitor session, "
+            "which makes short changes easier to see.</p>"
         ),
         styles={
             "background": WARM,
@@ -180,12 +225,11 @@ def build_document(document, sampler: CoalescedSampler) -> None:
     privacy = Div(
         text=(
             "<p><strong>What reaches your browser.</strong> Your browser receives only the numbers and labels "
-            "shown on this page. App routes come from the public gallery, and callback names come from a "
-            "fixed list in the source code. The page does not send task metadata, AWS identifiers, "
-            "credentials, logs, IP addresses, request headers, referrers, or query strings. The server reads "
-            "ECS stats at most once every two seconds and shares each reading among the monitor sessions on "
-            "that process. The activity counters keep only request timestamps and the number of live Bokeh "
-            "documents.</p>"
+            "shown on this page. App routes come from the public catalog, and callback names come from a "
+            "fixed list in the source. The page does not send task metadata, AWS identifiers, credentials, "
+            "logs, IP addresses, request headers, referrers, or query strings. Each task exchanges one "
+            "sanitized report every 30 seconds. Browser sessions share the cached result and never query AWS "
+            "directly.</p>"
         ),
         styles={
             "border-left": f"3px solid {GOLD}",
@@ -199,7 +243,40 @@ def build_document(document, sampler: CoalescedSampler) -> None:
 
     document.add_root(
         column(
-            status,
+            service_status,
+            metric_row(
+                tasks_card,
+                service_sessions_card,
+                service_pages_card,
+                service_callbacks_card,
+                sizing_mode="stretch_width",
+            ),
+            metric_row(
+                service_cpu_card,
+                service_memory_card,
+                service_network_card,
+                service_lag_card,
+                sizing_mode="stretch_width",
+            ),
+            explanation,
+            Div(
+                text=(
+                    "<h2 style='margin:8px 0 2px'>Service performance</h2>"
+                    "<p style='margin:0'>These tables combine the past 60 seconds reported by every fresh "
+                    "task. Percentiles come from merged fixed buckets, so they are approximate rather than "
+                    "averages of each task's p95.</p>"
+                ),
+                styles={"color": MUTED, "line-height": "1.55"},
+                sizing_mode="stretch_width",
+            ),
+            responsive_row(callback_apps, event_loop_apps, sizing_mode="stretch_width"),
+            slowest_callbacks,
+            Div(
+                text="<h2 style='margin:12px 0 2px'>This serving task</h2>",
+                styles={"color": MUTED},
+                sizing_mode="stretch_width",
+            ),
+            task_status,
             metric_row(
                 cpu_card,
                 memory_card,
@@ -209,19 +286,7 @@ def build_document(document, sampler: CoalescedSampler) -> None:
                 lag_card,
                 sizing_mode="stretch_width",
             ),
-            explanation,
             responsive_row(utilization, latency, sizing_mode="stretch_width"),
-            Div(
-                text=(
-                    "<h2 style='margin:8px 0 2px'>Where Python time is going</h2>"
-                    "<p style='margin:0'>These tables summarize the past 60 seconds of work handled by this "
-                    "Python process. App routes and callback names come from a fixed public list.</p>"
-                ),
-                styles={"color": MUTED, "line-height": "1.55"},
-                sizing_mode="stretch_width",
-            ),
-            responsive_row(callback_apps, event_loop_apps, sizing_mode="stretch_width"),
-            slowest_callbacks,
             network,
             privacy,
             sizing_mode="stretch_width",
@@ -274,6 +339,77 @@ def _update_cards(sample: MonitorSample, cpu, memory, sessions, requests, callba
     set_metric(lag, _milliseconds(sample.event_loop_p95_ms), label="Current process loop-lag p95")
 
 
+def _update_service_cards(
+    sample: ServiceSample,
+    tasks,
+    sessions,
+    pages,
+    cpu,
+    memory,
+    network,
+    callbacks,
+    lag,
+) -> None:
+    set_metric(tasks, str(sample.reporting_tasks), label="Fresh task reports")
+    set_metric(sessions, str(sample.active_sessions), label="Open Bokeh documents")
+    set_metric(pages, f"{sample.page_entries_per_minute:.0f} / min", label="Demo page entries")
+    cpu_value = "Unavailable"
+    if sample.cpu_vcpus is not None:
+        cpu_value = f"{sample.cpu_vcpus:.2f} vCPU"
+        if sample.cpu_percent is not None:
+            cpu_value += f" · {sample.cpu_percent:.1f}%"
+    set_metric(cpu, cpu_value, label="CPU used across fresh tasks")
+    memory_value = _mib(sample.memory_bytes)
+    if sample.memory_percent is not None:
+        memory_value += f" · {sample.memory_percent:.1f}%"
+    set_metric(memory, memory_value, label="Memory used across fresh tasks")
+    if sample.rx_bytes_per_second is None or sample.tx_bytes_per_second is None:
+        network_value = "Warming up"
+    else:
+        network_value = (
+            f"↓ {sample.rx_bytes_per_second / 1024:.0f} · "
+            f"↑ {sample.tx_bytes_per_second / 1024:.0f} KiB/s"
+        )
+    set_metric(network, network_value, label="Task network throughput")
+    callback_value = f"{sample.callback_rate:.1f} / s"
+    if sample.callback_p95_ms is not None:
+        callback_value += f" · p95 {sample.callback_p95_ms:.1f} ms"
+    set_metric(callbacks, callback_value, label="Callbacks across fresh tasks")
+    set_metric(lag, _milliseconds(sample.event_loop_p95_ms), label="Service loop-lag p95")
+
+
+def _service_status(sample: ServiceSample) -> str:
+    if sample.status == "simulated":
+        eyebrow = "SIMULATED WHOLE SERVICE"
+        detail = "Three repeatable task reports for local layout and interaction checks."
+    elif sample.source_label == "Local process registry":
+        eyebrow = "LIVE LOCAL PROCESS"
+        detail = "The local registry contains this Python process only. No AWS credentials are in use."
+    elif sample.status == "degraded":
+        eyebrow = "SERVICE VIEW DEGRADED"
+        reasons = {
+            "warming_up": "The first service report has not arrived yet.",
+            "no_fresh_heartbeats": "No task has published a fresh report in the last 75 seconds.",
+            "service_data_unavailable": "The sanitized service exchange is temporarily unavailable.",
+        }
+        detail = reasons.get(
+            sample.reason or "", "The service aggregate is temporarily unavailable."
+        )
+    else:
+        eyebrow = "LIVE DATA · WHOLE DEMO SERVICE"
+        detail = (
+            f"Combined from {sample.reporting_tasks} fresh task report"
+            f"{'s' if sample.reporting_tasks != 1 else ''}; refreshed every 30 seconds."
+        )
+    return (
+        f'<div style="width:100%;box-sizing:border-box;background:{PLUM};color:#f7f3ec;padding:18px 20px;'
+        f'border-left:5px solid {GOLD}">'
+        f'<div style="color:{GOLD};font:700 10px monospace;letter-spacing:.12em">{eyebrow}</div>'
+        f'<div style="font:400 25px Georgia,serif;margin-top:5px">{sample.source_label}</div>'
+        f'<div style="color:rgba(247,243,236,.7);font-size:12px;margin-top:6px">{detail}</div></div>'
+    )
+
+
 def _table_panel(title: str, *, name: str) -> Div:
     return Div(
         text=_empty_table(title),
@@ -290,7 +426,10 @@ def _table_panel(title: str, *, name: str) -> Div:
 
 
 def _update_timing_tables(
-    sample: MonitorSample, callback_apps: Div, event_loop_apps: Div, slowest_callbacks: Div
+    sample: MonitorSample | ServiceSample,
+    callback_apps: Div,
+    event_loop_apps: Div,
+    slowest_callbacks: Div,
 ) -> None:
     callback_apps.text = _app_table(
         "Callback latency by app", sample.callbacks_by_app, count_label="callbacks"
@@ -340,7 +479,7 @@ def _callback_table(timings: tuple[CallbackTiming, ...]) -> str:
 def _empty_table(title: str) -> str:
     return (
         f"<h3 style='color:{PLUM};font:600 18px Georgia,serif;margin:0 0 12px'>{title}</h3>"
-        f"<p style='color:{MUTED};font-size:12px;margin:0'>No activity in this process during the "
+        f"<p style='color:{MUTED};font-size:12px;margin:0'>No activity during the "
         "rolling window.</p>"
     )
 

--- a/apps/monitor/__init__.py
+++ b/apps/monitor/__init__.py
@@ -340,15 +340,7 @@ def _update_cards(sample: MonitorSample, cpu, memory, sessions, requests, callba
 
 
 def _update_service_cards(
-    sample: ServiceSample,
-    tasks,
-    sessions,
-    pages,
-    cpu,
-    memory,
-    network,
-    callbacks,
-    lag,
+    sample: ServiceSample, tasks, sessions, pages, cpu, memory, network, callbacks, lag
 ) -> None:
     set_metric(tasks, str(sample.reporting_tasks), label="Fresh task reports")
     set_metric(sessions, str(sample.active_sessions), label="Open Bokeh documents")
@@ -384,7 +376,9 @@ def _service_status(sample: ServiceSample) -> str:
         detail = "Three repeatable task reports for local layout and interaction checks."
     elif sample.source_label == "Local process registry":
         eyebrow = "LIVE LOCAL PROCESS"
-        detail = "The local registry contains this Python process only. No AWS credentials are in use."
+        detail = (
+            "The local registry contains this Python process only. No AWS credentials are in use."
+        )
     elif sample.status == "degraded":
         eyebrow = "SERVICE VIEW DEGRADED"
         reasons = {

--- a/apps/monitor/global_metrics.py
+++ b/apps/monitor/global_metrics.py
@@ -1,0 +1,648 @@
+"""Exchange and combine sanitized monitor heartbeats across demo tasks."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import secrets
+import zlib
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from threading import Event, Lock, Thread
+from time import monotonic, time
+from typing import Any, Protocol
+
+import boto3
+from botocore.config import Config
+
+from apps._common.performance import (
+    PUBLIC_APP_ROUTES,
+    PUBLIC_CALLBACKS_BY_ROUTE,
+    PUBLIC_LATENCY_BUCKETS_MS,
+    AppTiming,
+    CallbackTiming,
+    histogram_percentile,
+)
+
+from .metrics import CoalescedSampler, MonitorSample
+
+LOGGER = logging.getLogger("demo.monitor.global")
+HEARTBEAT_INTERVAL_SECONDS = 30.0
+HEARTBEAT_MAX_AGE_SECONDS = 75.0
+HEARTBEAT_TTL_SECONDS = 180
+MAX_ENCODED_BYTES = 32_768
+MAX_HEARTBEATS = 32
+
+
+@dataclass(frozen=True, slots=True)
+class Heartbeat:
+    """One task's sanitized contribution to the service view."""
+
+    published_at: float
+    expires_at: int
+    cpu_percent: float | None
+    cpu_capacity_vcpus: float | None
+    memory_bytes: float | None
+    memory_capacity_bytes: float | None
+    rx_bytes_per_second: float | None
+    tx_bytes_per_second: float | None
+    active_sessions: int
+    page_entries_per_minute: float
+    callback_count: int
+    callback_window_seconds: float
+    callback_max_ms: float | None
+    callback_histogram: tuple[int, ...]
+    event_loop_max_ms: float | None
+    event_loop_histogram: tuple[int, ...]
+    callbacks_by_app: tuple[AppTiming, ...]
+    event_loop_by_app: tuple[AppTiming, ...]
+    slowest_callbacks: tuple[CallbackTiming, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceSample:
+    """Browser-safe aggregate for all fresh reporting tasks."""
+
+    generation: int
+    timestamp_ms: float
+    status: str
+    reason: str | None
+    source_label: str
+    deterministic: bool
+    freshness_seconds: float | None
+    reporting_tasks: int
+    active_sessions: int
+    page_entries_per_minute: float
+    cpu_vcpus: float | None
+    cpu_percent: float | None
+    memory_bytes: float | None
+    memory_capacity_bytes: float | None
+    memory_percent: float | None
+    rx_bytes_per_second: float | None
+    tx_bytes_per_second: float | None
+    callback_rate: float
+    callback_p95_ms: float | None
+    event_loop_p95_ms: float | None
+    callbacks_by_app: tuple[AppTiming, ...]
+    event_loop_by_app: tuple[AppTiming, ...]
+    slowest_callbacks: tuple[CallbackTiming, ...]
+
+
+class HeartbeatStore(Protocol):
+    """Store sanitized task heartbeats."""
+
+    source_label: str
+    deterministic: bool
+
+    def put(self, publisher: str, heartbeat: Heartbeat) -> None: ...
+
+    def read(self) -> tuple[Heartbeat, ...]: ...
+
+
+class InMemoryHeartbeatStore:
+    """Real process-local adapter for development without AWS credentials."""
+
+    source_label = "Local process registry"
+    deterministic = False
+
+    def __init__(self) -> None:
+        self._items: dict[str, Heartbeat] = {}
+        self._lock = Lock()
+
+    def put(self, publisher: str, heartbeat: Heartbeat) -> None:
+        with self._lock:
+            self._items[publisher] = heartbeat
+
+    def read(self) -> tuple[Heartbeat, ...]:
+        with self._lock:
+            return tuple(self._items.values())
+
+
+class DeterministicHeartbeatStore(InMemoryHeartbeatStore):
+    """Repeatable multi-task adapter for screenshots and local UI work."""
+
+    source_label = "Simulated whole service"
+    deterministic = True
+
+    def read(self) -> tuple[Heartbeat, ...]:
+        items = super().read()
+        if not items:
+            return ()
+        base = items[0]
+        return (
+            base,
+            replace(
+                base,
+                cpu_percent=_scaled(base.cpu_percent, 0.72),
+                memory_bytes=_scaled(base.memory_bytes, 0.88),
+                rx_bytes_per_second=_scaled(base.rx_bytes_per_second, 0.65),
+                tx_bytes_per_second=_scaled(base.tx_bytes_per_second, 0.81),
+                active_sessions=max(1, base.active_sessions - 2),
+                page_entries_per_minute=base.page_entries_per_minute * 0.78,
+            ),
+            replace(
+                base,
+                cpu_percent=_scaled(base.cpu_percent, 1.16),
+                memory_bytes=_scaled(base.memory_bytes, 1.08),
+                rx_bytes_per_second=_scaled(base.rx_bytes_per_second, 1.24),
+                tx_bytes_per_second=_scaled(base.tx_bytes_per_second, 1.13),
+                active_sessions=base.active_sessions + 1,
+                page_entries_per_minute=base.page_entries_per_minute * 1.12,
+            ),
+        )
+
+
+class DynamoHeartbeatStore:
+    """Read and write the dedicated sanitized DynamoDB table."""
+
+    source_label = "Live aggregate from reporting ECS tasks"
+    deterministic = False
+
+    def __init__(self, table_name: str, *, client: Any | None = None) -> None:
+        if not table_name or any(character.isspace() for character in table_name):
+            raise ValueError("monitor table name must be non-empty and contain no whitespace")
+        if client is None:
+            client = boto3.client(
+                "dynamodb",
+                config=Config(connect_timeout=0.5, read_timeout=1.0, retries={"max_attempts": 2}),
+            )
+        self._table_name = table_name
+        self._client = client
+
+    def put(self, publisher: str, heartbeat: Heartbeat) -> None:
+        self._client.put_item(
+            TableName=self._table_name,
+            Item={
+                "publisher": {"S": publisher},
+                "updated_at": {"N": str(round(heartbeat.published_at, 3))},
+                "expires_at": {"N": str(heartbeat.expires_at)},
+                "payload": {"B": encode_heartbeat(heartbeat)},
+            },
+        )
+
+    def read(self) -> tuple[Heartbeat, ...]:
+        response = self._client.scan(
+            TableName=self._table_name,
+            ProjectionExpression="payload",
+            ConsistentRead=False,
+            Limit=MAX_HEARTBEATS,
+        )
+        heartbeats = []
+        for item in response.get("Items", ()):  # Publisher keys never leave DynamoDB.
+            payload = item.get("payload", {}).get("B") if isinstance(item, dict) else None
+            if isinstance(payload, (bytes, bytearray)):
+                try:
+                    heartbeats.append(decode_heartbeat(bytes(payload)))
+                except (TypeError, ValueError, zlib.error):
+                    LOGGER.warning("Discarded an invalid sanitized monitor heartbeat")
+        return tuple(heartbeats)
+
+
+class ServiceMonitor:
+    """Run one coalesced publisher and reader loop for the process."""
+
+    def __init__(
+        self,
+        sampler: CoalescedSampler,
+        store: HeartbeatStore,
+        *,
+        interval_seconds: float = HEARTBEAT_INTERVAL_SECONDS,
+        allow_deterministic: bool = False,
+    ) -> None:
+        self._sampler = sampler
+        self._store = store
+        self._interval_seconds = interval_seconds
+        self._allow_deterministic = allow_deterministic
+        self._publisher = secrets.token_hex(16)
+        self._generation = 0
+        self._sample = _unavailable_sample(0, "warming_up", self._store.source_label)
+        self._lock = Lock()
+        self._stop = Event()
+        self._thread: Thread | None = None
+
+    def start(self) -> None:
+        """Start the process-wide exchange loop once."""
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop.clear()
+            self._thread = Thread(target=self._run, name="demo-monitor-heartbeat", daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the exchange loop during ASGI shutdown."""
+        self._stop.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=2.0)
+
+    def sample(self) -> ServiceSample:
+        """Return the latest in-process aggregate without an AWS call."""
+        with self._lock:
+            return self._sample
+
+    def tick(self, *, now: float | None = None, sampled_at: float | None = None) -> ServiceSample:
+        """Publish this process and rebuild the service aggregate once."""
+        wall_time = time() if now is None else now
+        monotonic_time = monotonic() if sampled_at is None else sampled_at
+        local = self._sampler.sample(now=monotonic_time, wall_time=wall_time)
+        try:
+            if not local.deterministic or self._allow_deterministic:
+                self._store.put(self._publisher, heartbeat_from_sample(local, wall_time))
+            heartbeats = tuple(
+                heartbeat
+                for heartbeat in self._store.read()
+                if 0 <= wall_time - heartbeat.published_at <= HEARTBEAT_MAX_AGE_SECONDS
+            )
+            self._generation += 1
+            result = aggregate_heartbeats(
+                heartbeats,
+                generation=self._generation,
+                now=wall_time,
+                source_label=self._store.source_label,
+                deterministic=self._store.deterministic,
+            )
+        except Exception:
+            LOGGER.warning("Service monitor exchange failed", exc_info=True)
+            self._generation += 1
+            result = _unavailable_sample(
+                self._generation, "service_data_unavailable", self._store.source_label
+            )
+        with self._lock:
+            self._sample = result
+        return result
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self.tick()
+            self._stop.wait(self._interval_seconds)
+
+
+def create_service_monitor(
+    sampler: CoalescedSampler, environment: Mapping[str, str] = os.environ
+) -> ServiceMonitor:
+    """Select DynamoDB, local, or deterministic service aggregation."""
+    mode = environment.get("DEMO_MONITOR_GLOBAL_SOURCE", "auto").casefold()
+    deterministic = environment.get("DEMO_MONITOR_SOURCE", "auto").casefold() in {
+        "demo",
+        "deterministic",
+    }
+    if mode == "deterministic" or deterministic:
+        return ServiceMonitor(
+            sampler, DeterministicHeartbeatStore(), allow_deterministic=True
+        )
+    if mode not in {"auto", "dynamodb", "local"}:
+        raise ValueError("DEMO_MONITOR_GLOBAL_SOURCE must be auto, dynamodb, local, or deterministic")
+    table_name = environment.get("DEMO_MONITOR_TABLE")
+    if mode != "local" and table_name:
+        return ServiceMonitor(sampler, DynamoHeartbeatStore(table_name))
+    if mode == "dynamodb":
+        raise ValueError("DynamoDB monitor source requested without DEMO_MONITOR_TABLE")
+    return ServiceMonitor(sampler, InMemoryHeartbeatStore())
+
+
+def heartbeat_from_sample(sample: MonitorSample, published_at: float) -> Heartbeat:
+    """Copy only the explicit public fields into a storage heartbeat."""
+    return Heartbeat(
+        published_at=published_at,
+        expires_at=math.ceil(published_at + HEARTBEAT_TTL_SECONDS),
+        cpu_percent=sample.cpu_percent,
+        cpu_capacity_vcpus=sample.cpu_capacity_vcpus,
+        memory_bytes=sample.memory_bytes,
+        memory_capacity_bytes=sample.memory_capacity_bytes,
+        rx_bytes_per_second=sample.rx_bytes_per_second,
+        tx_bytes_per_second=sample.tx_bytes_per_second,
+        active_sessions=max(0, sample.active_sessions),
+        page_entries_per_minute=max(0.0, sample.requests_per_minute),
+        callback_count=max(0, sample.callback_count),
+        callback_window_seconds=max(1.0, sample.callback_window_seconds),
+        callback_max_ms=sample.callback_max_ms,
+        callback_histogram=sample.callback_histogram,
+        event_loop_max_ms=sample.event_loop_max_ms,
+        event_loop_histogram=sample.event_loop_histogram,
+        callbacks_by_app=sample.callbacks_by_app,
+        event_loop_by_app=sample.event_loop_by_app,
+        slowest_callbacks=sample.slowest_callbacks,
+    )
+
+
+def aggregate_heartbeats(
+    heartbeats: tuple[Heartbeat, ...],
+    *,
+    generation: int,
+    now: float,
+    source_label: str,
+    deterministic: bool,
+) -> ServiceSample:
+    """Combine fresh task rows without exposing their publisher keys."""
+    if not heartbeats:
+        return _unavailable_sample(generation, "no_fresh_heartbeats", source_label)
+    cpu_capacity = _sum_optional(heartbeat.cpu_capacity_vcpus for heartbeat in heartbeats)
+    cpu_vcpus = _sum_optional(
+        heartbeat.cpu_capacity_vcpus * heartbeat.cpu_percent / 100
+        for heartbeat in heartbeats
+        if heartbeat.cpu_capacity_vcpus is not None and heartbeat.cpu_percent is not None
+    )
+    memory = _sum_optional(heartbeat.memory_bytes for heartbeat in heartbeats)
+    memory_capacity = _sum_optional(heartbeat.memory_capacity_bytes for heartbeat in heartbeats)
+    callback_histogram = _merge_histograms(
+        heartbeat.callback_histogram for heartbeat in heartbeats
+    )
+    event_loop_histogram = _merge_histograms(
+        heartbeat.event_loop_histogram for heartbeat in heartbeats
+    )
+    callback_max = _max_optional(heartbeat.callback_max_ms for heartbeat in heartbeats)
+    event_loop_max = _max_optional(heartbeat.event_loop_max_ms for heartbeat in heartbeats)
+    return ServiceSample(
+        generation=generation,
+        timestamp_ms=1000 * now,
+        status="simulated" if deterministic else "ok",
+        reason=None,
+        source_label=source_label,
+        deterministic=deterministic,
+        freshness_seconds=max(0.0, now - max(item.published_at for item in heartbeats)),
+        reporting_tasks=len(heartbeats),
+        active_sessions=sum(item.active_sessions for item in heartbeats),
+        page_entries_per_minute=sum(item.page_entries_per_minute for item in heartbeats),
+        cpu_vcpus=cpu_vcpus,
+        cpu_percent=(
+            None if cpu_vcpus is None or not cpu_capacity else 100 * cpu_vcpus / cpu_capacity
+        ),
+        memory_bytes=memory,
+        memory_capacity_bytes=memory_capacity,
+        memory_percent=(
+            None if memory is None or not memory_capacity else 100 * memory / memory_capacity
+        ),
+        rx_bytes_per_second=_sum_optional(
+            heartbeat.rx_bytes_per_second for heartbeat in heartbeats
+        ),
+        tx_bytes_per_second=_sum_optional(
+            heartbeat.tx_bytes_per_second for heartbeat in heartbeats
+        ),
+        callback_rate=sum(
+            heartbeat.callback_count / heartbeat.callback_window_seconds
+            for heartbeat in heartbeats
+        ),
+        callback_p95_ms=histogram_percentile(callback_histogram, maximum=callback_max),
+        event_loop_p95_ms=histogram_percentile(event_loop_histogram, maximum=event_loop_max),
+        callbacks_by_app=_merge_app_timings(
+            timing for heartbeat in heartbeats for timing in heartbeat.callbacks_by_app
+        ),
+        event_loop_by_app=_merge_app_timings(
+            timing for heartbeat in heartbeats for timing in heartbeat.event_loop_by_app
+        ),
+        slowest_callbacks=_merge_callback_timings(
+            timing for heartbeat in heartbeats for timing in heartbeat.slowest_callbacks
+        ),
+    )
+
+
+def encode_heartbeat(heartbeat: Heartbeat) -> bytes:
+    """Encode the allowlisted contract as bounded compressed JSON."""
+    payload = {
+        "v": 1,
+        "at": heartbeat.published_at,
+        "ttl": heartbeat.expires_at,
+        "cpu": heartbeat.cpu_percent,
+        "cpu_cap": heartbeat.cpu_capacity_vcpus,
+        "mem": heartbeat.memory_bytes,
+        "mem_cap": heartbeat.memory_capacity_bytes,
+        "rx": heartbeat.rx_bytes_per_second,
+        "tx": heartbeat.tx_bytes_per_second,
+        "sessions": heartbeat.active_sessions,
+        "pages": heartbeat.page_entries_per_minute,
+        "cb_count": heartbeat.callback_count,
+        "window": heartbeat.callback_window_seconds,
+        "cb_max": heartbeat.callback_max_ms,
+        "cb_hist": heartbeat.callback_histogram,
+        "loop_max": heartbeat.event_loop_max_ms,
+        "loop_hist": heartbeat.event_loop_histogram,
+        "apps": [_encode_app(timing) for timing in heartbeat.callbacks_by_app],
+        "loops": [_encode_app(timing) for timing in heartbeat.event_loop_by_app],
+        "callbacks": [_encode_callback(timing) for timing in heartbeat.slowest_callbacks],
+    }
+    encoded = zlib.compress(json.dumps(payload, separators=(",", ":")).encode(), level=9)
+    if len(encoded) > MAX_ENCODED_BYTES:
+        raise ValueError("sanitized heartbeat exceeds its storage bound")
+    return encoded
+
+
+def decode_heartbeat(encoded: bytes) -> Heartbeat:
+    """Validate a stored heartbeat before it enters the public aggregate."""
+    if len(encoded) > MAX_ENCODED_BYTES:
+        raise ValueError("encoded heartbeat exceeds its storage bound")
+    decoder = zlib.decompressobj()
+    raw = decoder.decompress(encoded, MAX_ENCODED_BYTES + 1)
+    if decoder.unconsumed_tail or len(raw) > MAX_ENCODED_BYTES:
+        raise ValueError("decoded heartbeat exceeds its storage bound")
+    payload = json.loads(raw)
+    if not isinstance(payload, dict) or payload.get("v") != 1:
+        raise ValueError("unknown monitor heartbeat schema")
+    return Heartbeat(
+        published_at=_finite(payload.get("at")),
+        expires_at=int(_finite(payload.get("ttl"))),
+        cpu_percent=_optional_finite(payload.get("cpu")),
+        cpu_capacity_vcpus=_optional_finite(payload.get("cpu_cap")),
+        memory_bytes=_optional_finite(payload.get("mem")),
+        memory_capacity_bytes=_optional_finite(payload.get("mem_cap")),
+        rx_bytes_per_second=_optional_finite(payload.get("rx")),
+        tx_bytes_per_second=_optional_finite(payload.get("tx")),
+        active_sessions=max(0, int(_finite(payload.get("sessions")))),
+        page_entries_per_minute=max(0.0, _finite(payload.get("pages"))),
+        callback_count=max(0, int(_finite(payload.get("cb_count")))),
+        callback_window_seconds=max(1.0, _finite(payload.get("window"))),
+        callback_max_ms=_optional_finite(payload.get("cb_max")),
+        callback_histogram=_histogram(payload.get("cb_hist")),
+        event_loop_max_ms=_optional_finite(payload.get("loop_max")),
+        event_loop_histogram=_histogram(payload.get("loop_hist")),
+        callbacks_by_app=_decode_apps(payload.get("apps")),
+        event_loop_by_app=_decode_apps(payload.get("loops")),
+        slowest_callbacks=_decode_callbacks(payload.get("callbacks")),
+    )
+
+
+def _encode_app(timing: AppTiming) -> list[Any]:
+    return [timing.app, timing.count, timing.max_ms, timing.histogram]
+
+
+def _encode_callback(timing: CallbackTiming) -> list[Any]:
+    return [timing.app, timing.callback, timing.count, timing.max_ms, timing.histogram]
+
+
+def _decode_apps(value: object) -> tuple[AppTiming, ...]:
+    if not isinstance(value, list):
+        raise ValueError("app timings must be a list")
+    result = []
+    for row in value:
+        if not isinstance(row, list) or len(row) != 4 or row[0] not in PUBLIC_APP_ROUTES:
+            raise ValueError("app timing contains a non-public route")
+        histogram = _histogram(row[3])
+        maximum = max(0.0, _finite(row[2]))
+        result.append(
+            AppTiming(
+                app=row[0],
+                count=max(0, int(_finite(row[1]))),
+                p95_ms=histogram_percentile(histogram, maximum=maximum) or 0.0,
+                max_ms=maximum,
+                histogram=histogram,
+            )
+        )
+    return tuple(result)
+
+
+def _decode_callbacks(value: object) -> tuple[CallbackTiming, ...]:
+    if not isinstance(value, list):
+        raise ValueError("callback timings must be a list")
+    result = []
+    for row in value:
+        if (
+            not isinstance(row, list)
+            or len(row) != 5
+            or row[0] not in PUBLIC_APP_ROUTES
+            or row[1] not in PUBLIC_CALLBACKS_BY_ROUTE.get(row[0], ())
+        ):
+            raise ValueError("callback timing contains a non-public label")
+        histogram = _histogram(row[4])
+        maximum = max(0.0, _finite(row[3]))
+        result.append(
+            CallbackTiming(
+                app=row[0],
+                callback=row[1],
+                count=max(0, int(_finite(row[2]))),
+                p95_ms=histogram_percentile(histogram, maximum=maximum) or 0.0,
+                max_ms=maximum,
+                histogram=histogram,
+            )
+        )
+    return tuple(result)
+
+
+def _merge_app_timings(timings: Any) -> tuple[AppTiming, ...]:
+    grouped: dict[str, tuple[int, float, tuple[int, ...]]] = {}
+    for timing in timings:
+        count, maximum, histogram = grouped.get(
+            timing.app, (0, 0.0, tuple(0 for _ in timing.histogram))
+        )
+        grouped[timing.app] = (
+            count + timing.count,
+            max(maximum, timing.max_ms),
+            _merge_histograms((histogram, timing.histogram)),
+        )
+    result = (
+        AppTiming(
+            app=app,
+            count=count,
+            p95_ms=histogram_percentile(histogram, maximum=maximum) or 0.0,
+            max_ms=maximum,
+            histogram=histogram,
+        )
+        for app, (count, maximum, histogram) in grouped.items()
+    )
+    return tuple(sorted(result, key=lambda item: item.max_ms, reverse=True))[:8]
+
+
+def _merge_callback_timings(timings: Any) -> tuple[CallbackTiming, ...]:
+    grouped: dict[tuple[str, str], tuple[int, float, tuple[int, ...]]] = {}
+    for timing in timings:
+        key = (timing.app, timing.callback)
+        count, maximum, histogram = grouped.get(
+            key, (0, 0.0, tuple(0 for _ in timing.histogram))
+        )
+        grouped[key] = (
+            count + timing.count,
+            max(maximum, timing.max_ms),
+            _merge_histograms((histogram, timing.histogram)),
+        )
+    result = (
+        CallbackTiming(
+            app=app,
+            callback=callback,
+            count=count,
+            p95_ms=histogram_percentile(histogram, maximum=maximum) or 0.0,
+            max_ms=maximum,
+            histogram=histogram,
+        )
+        for (app, callback), (count, maximum, histogram) in grouped.items()
+    )
+    return tuple(sorted(result, key=lambda item: item.max_ms, reverse=True))[:12]
+
+
+def _histogram(value: object) -> tuple[int, ...]:
+    if (
+        not isinstance(value, (list, tuple))
+        or len(value) != len(PUBLIC_LATENCY_BUCKETS_MS) + 1
+    ):
+        raise ValueError("latency histogram has an invalid shape")
+    result = tuple(int(_finite(count)) for count in value)
+    if any(count < 0 for count in result):
+        raise ValueError("latency histogram counts must be non-negative")
+    return result
+
+
+def _merge_histograms(histograms: Any) -> tuple[int, ...]:
+    result: list[int] = []
+    for histogram in histograms:
+        if not result:
+            result = [0] * len(histogram)
+        if len(histogram) != len(result):
+            raise ValueError("latency histogram shapes do not match")
+        for index, count in enumerate(histogram):
+            result[index] += count
+    return tuple(result)
+
+
+def _finite(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("monitor measurement must be numeric")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError("monitor measurement must be finite")
+    return result
+
+
+def _optional_finite(value: object) -> float | None:
+    return None if value is None else _finite(value)
+
+
+def _sum_optional(values: Any) -> float | None:
+    present = [value for value in values if value is not None]
+    return sum(present) if present else None
+
+
+def _max_optional(values: Any) -> float | None:
+    present = [value for value in values if value is not None]
+    return max(present) if present else None
+
+
+def _scaled(value: float | None, factor: float) -> float | None:
+    return None if value is None else value * factor
+
+
+def _unavailable_sample(generation: int, reason: str, source_label: str) -> ServiceSample:
+    return ServiceSample(
+        generation=generation,
+        timestamp_ms=1000 * time(),
+        status="degraded",
+        reason=reason,
+        source_label=source_label,
+        deterministic=False,
+        freshness_seconds=None,
+        reporting_tasks=0,
+        active_sessions=0,
+        page_entries_per_minute=0.0,
+        cpu_vcpus=None,
+        cpu_percent=None,
+        memory_bytes=None,
+        memory_capacity_bytes=None,
+        memory_percent=None,
+        rx_bytes_per_second=None,
+        tx_bytes_per_second=None,
+        callback_rate=0.0,
+        callback_p95_ms=None,
+        event_loop_p95_ms=None,
+        callbacks_by_app=(),
+        event_loop_by_app=(),
+        slowest_callbacks=(),
+    )

--- a/apps/monitor/global_metrics.py
+++ b/apps/monitor/global_metrics.py
@@ -290,11 +290,11 @@ def create_service_monitor(
         "deterministic",
     }
     if mode == "deterministic" or deterministic:
-        return ServiceMonitor(
-            sampler, DeterministicHeartbeatStore(), allow_deterministic=True
-        )
+        return ServiceMonitor(sampler, DeterministicHeartbeatStore(), allow_deterministic=True)
     if mode not in {"auto", "dynamodb", "local"}:
-        raise ValueError("DEMO_MONITOR_GLOBAL_SOURCE must be auto, dynamodb, local, or deterministic")
+        raise ValueError(
+            "DEMO_MONITOR_GLOBAL_SOURCE must be auto, dynamodb, local, or deterministic"
+        )
     table_name = environment.get("DEMO_MONITOR_TABLE")
     if mode != "local" and table_name:
         return ServiceMonitor(sampler, DynamoHeartbeatStore(table_name))
@@ -347,9 +347,7 @@ def aggregate_heartbeats(
     )
     memory = _sum_optional(heartbeat.memory_bytes for heartbeat in heartbeats)
     memory_capacity = _sum_optional(heartbeat.memory_capacity_bytes for heartbeat in heartbeats)
-    callback_histogram = _merge_histograms(
-        heartbeat.callback_histogram for heartbeat in heartbeats
-    )
+    callback_histogram = _merge_histograms(heartbeat.callback_histogram for heartbeat in heartbeats)
     event_loop_histogram = _merge_histograms(
         heartbeat.event_loop_histogram for heartbeat in heartbeats
     )
@@ -382,8 +380,7 @@ def aggregate_heartbeats(
             heartbeat.tx_bytes_per_second for heartbeat in heartbeats
         ),
         callback_rate=sum(
-            heartbeat.callback_count / heartbeat.callback_window_seconds
-            for heartbeat in heartbeats
+            heartbeat.callback_count / heartbeat.callback_window_seconds for heartbeat in heartbeats
         ),
         callback_p95_ms=histogram_percentile(callback_histogram, maximum=callback_max),
         event_loop_p95_ms=histogram_percentile(event_loop_histogram, maximum=event_loop_max),
@@ -547,9 +544,7 @@ def _merge_callback_timings(timings: Any) -> tuple[CallbackTiming, ...]:
     grouped: dict[tuple[str, str], tuple[int, float, tuple[int, ...]]] = {}
     for timing in timings:
         key = (timing.app, timing.callback)
-        count, maximum, histogram = grouped.get(
-            key, (0, 0.0, tuple(0 for _ in timing.histogram))
-        )
+        count, maximum, histogram = grouped.get(key, (0, 0.0, tuple(0 for _ in timing.histogram)))
         grouped[key] = (
             count + timing.count,
             max(maximum, timing.max_ms),
@@ -570,10 +565,7 @@ def _merge_callback_timings(timings: Any) -> tuple[CallbackTiming, ...]:
 
 
 def _histogram(value: object) -> tuple[int, ...]:
-    if (
-        not isinstance(value, (list, tuple))
-        or len(value) != len(PUBLIC_LATENCY_BUCKETS_MS) + 1
-    ):
+    if not isinstance(value, (list, tuple)) or len(value) != len(PUBLIC_LATENCY_BUCKETS_MS) + 1:
         raise ValueError("latency histogram has an invalid shape")
     result = tuple(int(_finite(count)) for count in value)
     if any(count < 0 for count in result):

--- a/apps/monitor/metrics.py
+++ b/apps/monitor/metrics.py
@@ -24,6 +24,7 @@ from apps._common.performance import (
     CallbackTiming,
     PerformanceSnapshot,
     PublicPerformance,
+    latency_histogram,
 )
 
 LOGGER = logging.getLogger("demo.monitor")
@@ -43,6 +44,8 @@ class SystemSample:
     cpu_percent: float | None
     memory_bytes: float | None
     memory_percent: float | None
+    cpu_capacity_vcpus: float | None
+    memory_capacity_bytes: float | None
     rx_bytes_per_second: float | None
     tx_bytes_per_second: float | None
 
@@ -59,13 +62,21 @@ class MonitorSample:
     cpu_percent: float | None
     memory_bytes: float | None
     memory_percent: float | None
+    cpu_capacity_vcpus: float | None
+    memory_capacity_bytes: float | None
     rx_bytes_per_second: float | None
     tx_bytes_per_second: float | None
     active_sessions: int
     requests_per_minute: float
     callback_rate: float
+    callback_count: int
+    callback_window_seconds: float
     callback_p95_ms: float | None
+    callback_max_ms: float | None
+    callback_histogram: tuple[int, ...]
     event_loop_p95_ms: float | None
+    event_loop_max_ms: float | None
+    event_loop_histogram: tuple[int, ...]
     callbacks_by_app: tuple[AppTiming, ...]
     event_loop_by_app: tuple[AppTiming, ...]
     slowest_callbacks: tuple[CallbackTiming, ...]
@@ -159,6 +170,8 @@ class EcsTaskStatsAdapter:
             cpu_percent=max(0.0, task_cpu_percent / self._cpu_limit),
             memory_bytes=memory_bytes,
             memory_percent=max(0.0, 100 * memory_bytes / self._memory_limit_bytes),
+            cpu_capacity_vcpus=self._cpu_limit,
+            memory_capacity_bytes=self._memory_limit_bytes,
             rx_bytes_per_second=rx_rate,
             tx_bytes_per_second=tx_rate,
         )
@@ -264,6 +277,8 @@ class LocalProcessAdapter:
             cpu_percent=cpu_percent,
             memory_bytes=self._resident_memory(),
             memory_percent=None,
+            cpu_capacity_vcpus=None,
+            memory_capacity_bytes=None,
             rx_bytes_per_second=rx_rate,
             tx_bytes_per_second=tx_rate,
         )
@@ -312,6 +327,8 @@ class DeterministicAdapter:
             cpu_percent=31 + 13 * math.sin(phase) + 4 * math.sin(phase * 2.7),
             memory_bytes=(790 + 28 * math.sin(phase / 2)) * MIB,
             memory_percent=38.5 + 1.4 * math.sin(phase / 2),
+            cpu_capacity_vcpus=1.0,
+            memory_capacity_bytes=2048 * MIB,
             rx_bytes_per_second=42_000 + 24_000 * (1 + math.sin(phase * 1.4)),
             tx_bytes_per_second=18_000 + 11_000 * (1 + math.cos(phase * 1.1)),
         )
@@ -373,13 +390,21 @@ class CoalescedSampler:
                 cpu_percent=system.cpu_percent,
                 memory_bytes=system.memory_bytes,
                 memory_percent=system.memory_percent,
+                cpu_capacity_vcpus=system.cpu_capacity_vcpus,
+                memory_capacity_bytes=system.memory_capacity_bytes,
                 rx_bytes_per_second=system.rx_bytes_per_second,
                 tx_bytes_per_second=system.tx_bytes_per_second,
                 active_sessions=active_sessions,
                 requests_per_minute=requests_per_minute,
                 callback_rate=performance.callback_count / performance.window_seconds,
+                callback_count=performance.callback_count,
+                callback_window_seconds=performance.window_seconds,
                 callback_p95_ms=performance.callback_p95_ms,
+                callback_max_ms=performance.callback_max_ms,
+                callback_histogram=performance.callback_histogram,
                 event_loop_p95_ms=performance.event_loop_p95_ms,
+                event_loop_max_ms=performance.event_loop_max_ms,
+                event_loop_histogram=performance.event_loop_histogram,
                 callbacks_by_app=performance.callbacks_by_app,
                 event_loop_by_app=performance.event_loop_by_app,
                 slowest_callbacks=performance.slowest_callbacks,
@@ -434,33 +459,50 @@ def _optional_number(value: object) -> float | None:
 def _deterministic_performance(index: int) -> PerformanceSnapshot:
     phase = index / 6
     callbacks_by_app = (
-        AppTiming("/image-processing", 18, 24.8 + 3 * math.sin(phase), 41.2),
-        AppTiming("/market-monitor", 84, 5.2 + math.sin(phase), 8.7),
-        AppTiming("/chaotic-motion", 126, 2.8 + 0.5 * math.sin(phase), 4.9),
-        AppTiming("/cellular-automata", 210, 1.1 + 0.2 * math.sin(phase), 1.8),
+        _deterministic_app("/image-processing", 18, 24.8 + 3 * math.sin(phase), 41.2),
+        _deterministic_app("/market-monitor", 84, 5.2 + math.sin(phase), 8.7),
+        _deterministic_app("/chaotic-motion", 126, 2.8 + 0.5 * math.sin(phase), 4.9),
+        _deterministic_app("/cellular-automata", 210, 1.1 + 0.2 * math.sin(phase), 1.8),
     )
     event_loop_by_app = (
-        AppTiming("/chaotic-motion", 34, 8.4 + 2 * math.sin(phase), 13.7),
-        AppTiming("/climate", 18, 4.2 + math.sin(phase), 7.9),
-        AppTiming("/image-processing", 42, 1.3 + 0.2 * math.sin(phase), 2.4),
-        AppTiming("/market-monitor", 52, 0.8 + 0.1 * math.sin(phase), 1.4),
+        _deterministic_app("/chaotic-motion", 34, 8.4 + 2 * math.sin(phase), 13.7),
+        _deterministic_app("/climate", 18, 4.2 + math.sin(phase), 7.9),
+        _deterministic_app("/image-processing", 42, 1.3 + 0.2 * math.sin(phase), 2.4),
+        _deterministic_app("/market-monitor", 52, 0.8 + 0.1 * math.sin(phase), 1.4),
     )
     slowest_callbacks = (
-        CallbackTiming("/image-processing", "update_strength", 18, 24.8, 41.2),
-        CallbackTiming("/market-monitor", "advance", 78, 5.4, 8.7),
-        CallbackTiming("/chaotic-motion", "advance_active", 121, 2.9, 4.9),
-        CallbackTiming("/cellular-automata", "advance", 204, 1.1, 1.8),
+        _deterministic_callback("/image-processing", "update_strength", 18, 24.8, 41.2),
+        _deterministic_callback("/market-monitor", "advance", 78, 5.4, 8.7),
+        _deterministic_callback("/chaotic-motion", "advance_active", 121, 2.9, 4.9),
+        _deterministic_callback("/cellular-automata", "advance", 204, 1.1, 1.8),
     )
+    callback_p95 = 7.5 + 2.8 * (1 + math.sin(phase * 1.7))
+    event_loop_p95 = 1.6 + 0.9 * (1 + math.cos(phase * 1.3))
+    callback_count = round(480 + 140 * (1 + math.sin(phase * 1.2)))
     return PerformanceSnapshot(
         window_seconds=60.0,
-        callback_count=round(480 + 140 * (1 + math.sin(phase * 1.2))),
-        callback_p95_ms=7.5 + 2.8 * (1 + math.sin(phase * 1.7)),
+        callback_count=callback_count,
+        callback_p95_ms=callback_p95,
         callback_max_ms=18 + 5 * (1 + math.sin(phase)),
-        event_loop_p95_ms=1.6 + 0.9 * (1 + math.cos(phase * 1.3)),
+        event_loop_p95_ms=event_loop_p95,
         event_loop_max_ms=5 + 2 * (1 + math.cos(phase)),
+        callback_histogram=latency_histogram([callback_p95] * callback_count),
+        event_loop_histogram=latency_histogram([event_loop_p95] * 60),
         callbacks_by_app=callbacks_by_app,
         event_loop_by_app=event_loop_by_app,
         slowest_callbacks=slowest_callbacks,
+    )
+
+
+def _deterministic_app(app: str, count: int, p95_ms: float, max_ms: float) -> AppTiming:
+    return AppTiming(app, count, p95_ms, max_ms, latency_histogram([p95_ms] * count))
+
+
+def _deterministic_callback(
+    app: str, callback: str, count: int, p95_ms: float, max_ms: float
+) -> CallbackTiming:
+    return CallbackTiming(
+        app, callback, count, p95_ms, max_ms, latency_histogram([p95_ms] * count)
     )
 
 

--- a/apps/monitor/metrics.py
+++ b/apps/monitor/metrics.py
@@ -501,9 +501,7 @@ def _deterministic_app(app: str, count: int, p95_ms: float, max_ms: float) -> Ap
 def _deterministic_callback(
     app: str, callback: str, count: int, p95_ms: float, max_ms: float
 ) -> CallbackTiming:
-    return CallbackTiming(
-        app, callback, count, p95_ms, max_ms, latency_histogram([p95_ms] * count)
-    )
+    return CallbackTiming(app, callback, count, p95_ms, max_ms, latency_histogram([p95_ms] * count))
 
 
 def _deterministic_activity(index: int) -> tuple[int, float]:

--- a/asgi.py
+++ b/asgi.py
@@ -15,6 +15,7 @@ from xml.sax.saxutils import escape
 from bokeh.server.asgi import BokehASGI
 
 from apps._common.activity import PUBLIC_ACTIVITY, PublicActivity
+from apps.monitor import SERVICE_MONITOR
 from catalog import DEMOS, LISTED_DEMOS, load_applications
 from presentation import ROOT, SITE_ORIGIN, render_index
 
@@ -91,7 +92,11 @@ class DemoApplication:
             self._activity.record_request()
 
         if scope_type == "lifespan":
-            await self._bokeh(scope, receive, send)
+            SERVICE_MONITOR.start()
+            try:
+                await self._bokeh(scope, receive, send)
+            finally:
+                SERVICE_MONITOR.stop()
         elif scope_type == "http" and path.rstrip("/") in LEGACY_DEMO_ROUTES:
             await self._redirect(scope, send, "/?legacy-demo=1#demos")
         elif scope_type == "http" and path in ("/", "/index.html"):

--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -5,6 +5,7 @@
   "cpu": "1024",
   "memory": "2048",
   "executionRoleArn": "arn:aws:iam::562605262404:role/demo-bokeh-org-task-execution",
+  "taskRoleArn": "arn:aws:iam::562605262404:role/demo-bokeh-org-task",
   "runtimePlatform": {
     "cpuArchitecture": "ARM64",
     "operatingSystemFamily": "LINUX"
@@ -33,6 +34,7 @@
         {"name": "BOKEH_RESOURCES", "value": "cdn"},
         {"name": "DEMO_MONITOR_TASK_CPU_LIMIT", "value": "1"},
         {"name": "DEMO_MONITOR_TASK_MEMORY_LIMIT_MIB", "value": "2048"},
+        {"name": "DEMO_MONITOR_TABLE", "value": "demo-bokeh-org-monitor"},
         {"name": "PORT", "value": "5006"},
         {"name": "PYTHONDONTWRITEBYTECODE", "value": "1"}
       ],

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -1,89 +1,105 @@
 # Public monitor data source and privacy boundary
 
-`/monitor` is an intentionally small teaching view of the server currently
-serving its Bokeh session. It is not an operations dashboard and does not claim
-to describe the whole ECS service.
+`/monitor` has two views. The whole-service section combines sanitized reports
+from every fresh demo task. The serving-task section shows faster local samples
+from the ECS task handling the browser session.
 
 ## Measurement scopes
 
-| Measurement | Production scope | Local scope |
+| Measurement | Whole-service scope | Serving-task scope |
 | --- | --- | --- |
-| CPU and memory | Current serving ECS task | Current Python process |
-| Network receive/send rate | Current serving ECS task | Local container when available |
-| Active Bokeh sessions | Current Python process | Current Python process |
-| Page requests per minute | Current Python process | Current Python process |
-| Callback rate and p95 duration | Current Python process | Current Python process |
-| Callback latency by app and slowest named callbacks | Current Python process | Current Python process |
-| Event-loop lag p95 and app breakdown | Current Python process | Current Python process |
+| CPU | Sum in vCPUs and capacity-weighted percentage | Current task percentage |
+| Memory | Sum of bytes and task capacities | Current task bytes and percentage |
+| Network | Sum of current task receive/send rates | Current task receive/send rate |
+| Open sessions | Sum of open Bokeh documents | Current Python process |
+| Page entries | Sum of demo page entries per minute | Current Python process |
+| Callback timing | Merged 60-second task histograms | Current Python process |
+| Event-loop lag | Merged 60-second task histograms | Current Python process |
 
-Active sessions are open Bokeh documents, not unique people. The request rate
-counts gallery and demo page entries, excluding assets, health checks, and the
-monitor's own traffic. Another ECS task may serve another visitor. Service-wide
-task count, request rate, errors, and load-balancer measurements remain private
-operational data and are not inferred or shown.
+An open session is a Bokeh document, not a unique person. Page entries count
+gallery and demo page visits. They exclude static assets, health checks, and the
+monitor itself. Cloudflare may serve static assets without contacting the demo
+service.
 
-## Production source
+## Production sources
 
-The application reads the automatically injected, link-local ECS task metadata
-v4 `/task/stats` endpoint. It does not use AWS credentials or make an AWS API
-request. The adapter ignores response keys and identity-bearing fields and
-allowlists only these numeric inputs:
+Each process samples its ECS task from the injected, link-local metadata v4
+`/task/stats` endpoint. The adapter ignores response keys and all string fields.
+It retains CPU counters, memory usage, network byte counters or rates, and the
+numeric task limits supplied by the task definition. It never calls `/task` or
+`/taskWithTags`.
 
-- cumulative CPU usage, system CPU usage, and online CPU count;
-- current memory usage;
-- cumulative or precomputed network receive/send byte rates; and
-- the numeric task CPU and memory limits supplied by the task definition.
+Once every 30 seconds, each process writes one sanitized heartbeat to the
+dedicated DynamoDB table named by `DEMO_MONITOR_TABLE`. It then scans the same
+table for reports no more than 75 seconds old. The process caches the resulting
+service sample, so opening or refreshing `/monitor` does not make an AWS call.
+The application starts this exchange loop with the ASGI lifespan and stops it
+during shutdown.
 
-The application never calls `/task`, `/taskWithTags`, CloudWatch, Logs Insights,
-or a public AWS endpoint. In particular, `/taskWithTags` is excluded because it
-requires IAM permission and can make ECS API calls.
+Heartbeat rows expire after three minutes. The reader checks timestamps itself
+because DynamoDB TTL deletion is asynchronous. A row contains a random
+publisher key, timestamps, numeric aggregates, public catalog routes, and
+allowlisted callback names. The publisher key stays in DynamoDB and is excluded
+from the scan projection and browser model.
 
-The numeric task limits are duplicated in the deployment template so the app
-can normalize measurements without reading the identity-rich task metadata
-response. Keep them aligned with the task definition's `cpu` and `memory`
-values when changing task size.
+## Timing aggregation
+
+The callback and event-loop collectors keep bounded 60-second process windows.
+They convert durations into fixed millisecond buckets before publication. The
+service view sums matching buckets and calculates an approximate global p95.
+This avoids the incorrect practice of averaging each task's p95.
+
+The service tables contain no more than eight app rows and twelve named callback
+rows. Routes must exist in the public catalog. Callback names must also appear
+in the source-code allowlist. The decoder rejects an entire heartbeat if either
+kind of label fails validation.
 
 ## Browser contract
 
-The Bokeh document contains timestamps, numeric measurements, fixed generic
-source labels, public routes already listed in the site catalog, and callback
-identifiers from an explicit allowlist of functions in this public repository.
-The request counter retains only bounded timestamps, not request paths or
-contents. The session counter keeps weak references to live Bokeh documents.
-An unknown route or callback label is discarded before it can enter a public
-snapshot. The document contains no AWS account IDs, ARNs, resource names,
-endpoint URI, credentials, task/container IDs, raw logs, source IPs, user
-agents, referrers, request headers, or query strings.
+The Bokeh document may contain only timestamps, numeric measurements, generic
+status text, public catalog routes, and allowlisted callback names. It must not
+contain AWS account IDs, ARNs, resource names, endpoint URIs, credentials,
+task or container identifiers, raw logs, source IPs, user agents, referrers,
+request headers, or query strings.
 
-Existing callback-duration and event-loop-lag instrumentation feeds bounded
-60-second process aggregates. Session and log identity are always discarded.
-Only catalog routes and explicitly allowlisted code-level callback names can be
-retained for the three performance tables. Event-loop observations are
-coalesced to at most one per process-wide one-second bucket for the headline
-metric and one per public route per second for the route breakdown.
+The DynamoDB payload follows the same boundary. It is compressed to keep each
+write below 1 KiB under the configured row limits, but compression is not a
+privacy control. Validation before writing and again after reading is the
+privacy control.
 
 ## Update and cost controls
 
-Every monitor session asks for a point every two seconds. A process-wide sampler
-performs at most one source read in that interval and shares the same generation
-with all viewers. Sessions skip duplicate generations and append one numeric row
-with `ColumnDataSource.stream`; browser history rolls over after 90 points. The
-small table snapshots are capped at eight app rows and twelve callback rows;
-their underlying in-memory samples also have fixed upper bounds.
+Serving-task plots poll the process cache every two seconds and retain 90 points
+with `ColumnDataSource.stream`. System sampling is coalesced across viewers.
+The service publisher and reader run once per process every 30 seconds, even
+when no monitor page is open.
 
-The link-local metadata endpoint is provided with the running Fargate task. The
-monitor adds no custom metrics, scheduled compute, log queries, storage pipeline,
-or public CloudWatch access, so it has no meaningful recurring AWS cost. It does
-add the small bounded CPU and WebSocket traffic needed to render the public app.
+At the four-task maximum, the service performs about 346,000 heartbeat writes
+per month. Compact on-demand DynamoDB writes and coalesced scans are expected to
+cost well below one US dollar per month. The design has no Lambda function,
+scheduled job, custom metric, Logs Insights query, public CloudWatch access, or
+new network path.
 
 ## Local and deterministic modes
 
-Without `ECS_CONTAINER_METADATA_URI_V4`, `auto` mode uses real process CPU and
-resident-memory measurements. Container network counters are used on local
-Linux containers when available; an unavailable network series remains empty.
-No AWS credentials are needed.
+Without ECS metadata or `DEMO_MONITOR_TABLE`, automatic mode uses real process
+CPU, resident memory, activity, and timing measurements with an in-memory
+heartbeat store. Local Linux containers also expose network counters when
+available. This mode needs no AWS credentials.
 
-Set `DEMO_MONITOR_SOURCE=deterministic` for repeatable presentation data. The UI
-labels that mode as simulated. If a selected live adapter fails, the monitor also
-uses a generic, clearly labeled deterministic fallback rather than exposing an
-exception or endpoint detail to the browser.
+Set `DEMO_MONITOR_SOURCE=deterministic` to generate repeatable serving-task data
+and three simulated service reports. The page labels both sections as simulated.
+`DEMO_MONITOR_GLOBAL_SOURCE=local` forces the in-memory store, while
+`DEMO_MONITOR_GLOBAL_SOURCE=dynamodb` requires `DEMO_MONITOR_TABLE`.
+
+If the live task adapter fails, the serving-task section uses a labeled
+deterministic fallback. A fallback sample is not published to the live service
+aggregate. If the heartbeat exchange fails or all rows are stale, the service
+section reports a degraded state with a generic reason and leaves local task
+measurements available.
+
+## Deployment order
+
+The Infra change creates the table and task role and grants the GitHub deployment
+role permission to pass that task role. Apply that reviewed change before merging
+an application release containing `taskRoleArn` and `DEMO_MONITOR_TABLE`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "The interactive application gallery for demo.bokeh.org"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "boto3>=1.42,<2",
     "bokeh[extra,sampledata]==3.10.0",
     "networkx>=3.5,<4",
     "numba>=0.61,<1",

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -23,7 +23,7 @@ def test_ecs_task_uses_arm64_fargate() -> None:
     assert task["runtimePlatform"] == {"cpuArchitecture": "ARM64", "operatingSystemFamily": "LINUX"}
 
 
-def test_monitor_receives_only_numeric_task_limits_and_needs_no_task_role() -> None:
+def test_monitor_receives_sanitized_exchange_configuration() -> None:
     task = json.loads((ROOT / "deploy" / "ecs-task-definition.json").read_text())
     environment = {
         item["name"]: item["value"] for item in task["containerDefinitions"][0]["environment"]
@@ -31,7 +31,8 @@ def test_monitor_receives_only_numeric_task_limits_and_needs_no_task_role() -> N
 
     assert environment["DEMO_MONITOR_TASK_CPU_LIMIT"] == "1"
     assert environment["DEMO_MONITOR_TASK_MEMORY_LIMIT_MIB"] == "2048"
-    assert "taskRoleArn" not in task
+    assert environment["DEMO_MONITOR_TABLE"] == "demo-bokeh-org-monitor"
+    assert task["taskRoleArn"].endswith(":role/demo-bokeh-org-task")
 
 
 def test_deployment_builds_the_matching_arm64_image() -> None:

--- a/tests/test_global_monitor.py
+++ b/tests/test_global_monitor.py
@@ -1,0 +1,231 @@
+"""Test the sanitized service-wide monitor exchange."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from apps._common.performance import (
+    PUBLIC_APP_ROUTES,
+    PUBLIC_CALLBACKS_BY_ROUTE,
+    AppTiming,
+    CallbackTiming,
+    latency_histogram,
+)
+from apps.monitor.global_metrics import (
+    DynamoHeartbeatStore,
+    Heartbeat,
+    ServiceMonitor,
+    aggregate_heartbeats,
+    decode_heartbeat,
+    encode_heartbeat,
+)
+from apps.monitor.metrics import CoalescedSampler, SystemSample
+
+
+def heartbeat(*, published_at: float = 100, cpu_percent: float = 50) -> Heartbeat:
+    callback_histogram = latency_histogram([1.0, 2.0, 4.0, 8.0])
+    loop_histogram = latency_histogram([0.5, 1.0, 2.0])
+    return Heartbeat(
+        published_at=published_at,
+        expires_at=280,
+        cpu_percent=cpu_percent,
+        cpu_capacity_vcpus=1.0,
+        memory_bytes=512 * 1024 * 1024,
+        memory_capacity_bytes=2 * 1024 * 1024 * 1024,
+        rx_bytes_per_second=2048,
+        tx_bytes_per_second=1024,
+        active_sessions=3,
+        page_entries_per_minute=12,
+        callback_count=4,
+        callback_window_seconds=60,
+        callback_max_ms=8.0,
+        callback_histogram=callback_histogram,
+        event_loop_max_ms=2.0,
+        event_loop_histogram=loop_histogram,
+        callbacks_by_app=(
+            AppTiming("/market-monitor", 4, 8.0, 8.0, callback_histogram),
+        ),
+        event_loop_by_app=(
+            AppTiming("/market-monitor", 3, 2.0, 2.0, loop_histogram),
+        ),
+        slowest_callbacks=(
+            CallbackTiming("/market-monitor", "advance", 4, 8.0, 8.0, callback_histogram),
+        ),
+    )
+
+
+def test_heartbeat_round_trip_preserves_only_public_aggregates() -> None:
+    original = heartbeat()
+
+    encoded = encode_heartbeat(original)
+    decoded = decode_heartbeat(encoded)
+
+    assert len(encoded) < 1024
+    assert decoded == original
+
+
+def test_maximum_public_tables_keep_the_compressed_payload_below_one_kibibyte() -> None:
+    histogram = latency_histogram([0.5, 1, 2, 4, 8, 16, 32, 64])
+    apps = tuple(
+        AppTiming(route, 8, 64, 64, histogram) for route in sorted(PUBLIC_APP_ROUTES)[:8]
+    )
+    callback_labels = (
+        (route, callback)
+        for route, callbacks in sorted(PUBLIC_CALLBACKS_BY_ROUTE.items())
+        for callback in sorted(callbacks)
+    )
+    callbacks = tuple(
+        CallbackTiming(route, callback, 8, 64, 64, histogram)
+        for route, callback in list(callback_labels)[:12]
+    )
+    maximum = replace(
+        heartbeat(),
+        callbacks_by_app=apps,
+        event_loop_by_app=apps,
+        slowest_callbacks=callbacks,
+    )
+
+    assert len(encode_heartbeat(maximum)) < 900
+
+
+def test_decoder_rejects_non_public_labels() -> None:
+    private = replace(
+        heartbeat(),
+        callbacks_by_app=(AppTiming("arn:aws:ecs:private", 1, 1, 1, latency_histogram([1])),),
+    )
+
+    with pytest.raises(ValueError, match="non-public route"):
+        decode_heartbeat(encode_heartbeat(private))
+
+
+def test_service_aggregate_sums_capacity_and_merges_histograms() -> None:
+    first = heartbeat(cpu_percent=50)
+    second = replace(
+        heartbeat(cpu_percent=100),
+        active_sessions=5,
+        page_entries_per_minute=8,
+        memory_bytes=1024 * 1024 * 1024,
+    )
+
+    sample = aggregate_heartbeats(
+        (first, second),
+        generation=4,
+        now=110,
+        source_label="Live aggregate from reporting ECS tasks",
+        deterministic=False,
+    )
+
+    assert sample.status == "ok"
+    assert sample.reporting_tasks == 2
+    assert sample.active_sessions == 8
+    assert sample.page_entries_per_minute == 20
+    assert sample.cpu_vcpus == pytest.approx(1.5)
+    assert sample.cpu_percent == pytest.approx(75)
+    assert sample.memory_bytes == 1536 * 1024 * 1024
+    assert sample.memory_percent == pytest.approx(37.5)
+    assert sample.rx_bytes_per_second == 4096
+    assert sample.callback_rate == pytest.approx(8 / 60)
+    assert sample.callback_p95_ms == 8
+    assert sample.callbacks_by_app[0].count == 8
+    assert sample.slowest_callbacks[0].callback == "advance"
+
+
+def test_service_monitor_ignores_stale_rows_before_ttl_deletes_them() -> None:
+    class Adapter:
+        def sample(self, *, now: float) -> SystemSample:
+            del now
+            return SystemSample(
+                "Live test process", "process", False, 25, 10, None, 1, 100, 2, 1
+            )
+
+    class Store:
+        source_label = "Test service"
+        deterministic = False
+
+        def put(self, _publisher: str, _row: Heartbeat) -> None:
+            return None
+
+        def read(self) -> tuple[Heartbeat, ...]:
+            return (heartbeat(published_at=1),)
+
+    sample = ServiceMonitor(CoalescedSampler(Adapter()), Store()).tick(now=100, sampled_at=10)
+
+    assert sample.status == "degraded"
+    assert sample.reason == "no_fresh_heartbeats"
+    assert sample.reporting_tasks == 0
+
+
+class DynamoClient:
+    def __init__(self) -> None:
+        self.put: dict | None = None
+        self.scan_arguments: dict | None = None
+
+    def put_item(self, **arguments) -> None:
+        self.put = arguments
+
+    def scan(self, **arguments):
+        self.scan_arguments = arguments
+        assert self.put is not None
+        return {"Items": [{"payload": self.put["Item"]["payload"]}]}
+
+
+def test_dynamo_store_never_reads_or_returns_publisher_keys() -> None:
+    client = DynamoClient()
+    store = DynamoHeartbeatStore("monitor-table", client=client)
+
+    store.put("opaque-private-publisher", heartbeat())
+    rows = store.read()
+
+    assert rows == (heartbeat(),)
+    assert client.scan_arguments == {
+        "TableName": "monitor-table",
+        "ProjectionExpression": "payload",
+        "ConsistentRead": False,
+        "Limit": 32,
+    }
+    assert client.put is not None
+    assert "opaque-private-publisher" not in repr(rows)
+
+
+def test_service_monitor_reads_store_only_during_coalesced_tick() -> None:
+    class Adapter:
+        def sample(self, *, now: float) -> SystemSample:
+            del now
+            return SystemSample(
+                source_label="Live test process",
+                scope="process",
+                deterministic=False,
+                cpu_percent=25,
+                memory_bytes=10,
+                memory_percent=None,
+                cpu_capacity_vcpus=1,
+                memory_capacity_bytes=100,
+                rx_bytes_per_second=2,
+                tx_bytes_per_second=1,
+            )
+
+    class Store:
+        source_label = "Test service"
+        deterministic = False
+        reads = 0
+        row: Heartbeat | None = None
+
+        def put(self, _publisher: str, row: Heartbeat) -> None:
+            self.row = row
+
+        def read(self) -> tuple[Heartbeat, ...]:
+            self.reads += 1
+            return () if self.row is None else (self.row,)
+
+    store = Store()
+    monitor = ServiceMonitor(CoalescedSampler(Adapter()), store)
+
+    updated = monitor.tick(now=100, sampled_at=10)
+    first_viewer = monitor.sample()
+    second_viewer = monitor.sample()
+
+    assert updated.reporting_tasks == 1
+    assert first_viewer is second_viewer
+    assert store.reads == 1

--- a/tests/test_global_monitor.py
+++ b/tests/test_global_monitor.py
@@ -44,12 +44,8 @@ def heartbeat(*, published_at: float = 100, cpu_percent: float = 50) -> Heartbea
         callback_histogram=callback_histogram,
         event_loop_max_ms=2.0,
         event_loop_histogram=loop_histogram,
-        callbacks_by_app=(
-            AppTiming("/market-monitor", 4, 8.0, 8.0, callback_histogram),
-        ),
-        event_loop_by_app=(
-            AppTiming("/market-monitor", 3, 2.0, 2.0, loop_histogram),
-        ),
+        callbacks_by_app=(AppTiming("/market-monitor", 4, 8.0, 8.0, callback_histogram),),
+        event_loop_by_app=(AppTiming("/market-monitor", 3, 2.0, 2.0, loop_histogram),),
         slowest_callbacks=(
             CallbackTiming("/market-monitor", "advance", 4, 8.0, 8.0, callback_histogram),
         ),
@@ -68,9 +64,7 @@ def test_heartbeat_round_trip_preserves_only_public_aggregates() -> None:
 
 def test_maximum_public_tables_keep_the_compressed_payload_below_one_kibibyte() -> None:
     histogram = latency_histogram([0.5, 1, 2, 4, 8, 16, 32, 64])
-    apps = tuple(
-        AppTiming(route, 8, 64, 64, histogram) for route in sorted(PUBLIC_APP_ROUTES)[:8]
-    )
+    apps = tuple(AppTiming(route, 8, 64, 64, histogram) for route in sorted(PUBLIC_APP_ROUTES)[:8])
     callback_labels = (
         (route, callback)
         for route, callbacks in sorted(PUBLIC_CALLBACKS_BY_ROUTE.items())
@@ -81,10 +75,7 @@ def test_maximum_public_tables_keep_the_compressed_payload_below_one_kibibyte() 
         for route, callback in list(callback_labels)[:12]
     )
     maximum = replace(
-        heartbeat(),
-        callbacks_by_app=apps,
-        event_loop_by_app=apps,
-        slowest_callbacks=callbacks,
+        heartbeat(), callbacks_by_app=apps, event_loop_by_app=apps, slowest_callbacks=callbacks
     )
 
     assert len(encode_heartbeat(maximum)) < 900
@@ -136,9 +127,7 @@ def test_service_monitor_ignores_stale_rows_before_ttl_deletes_them() -> None:
     class Adapter:
         def sample(self, *, now: float) -> SystemSample:
             del now
-            return SystemSample(
-                "Live test process", "process", False, 25, 10, None, 1, 100, 2, 1
-            )
+            return SystemSample("Live test process", "process", False, 25, 10, None, 1, 100, 2, 1)
 
     class Store:
         source_label = "Test service"

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -12,6 +12,7 @@ from bokeh.document import Document
 
 from apps._common.performance import PublicPerformance
 from apps.monitor import build_document
+from apps.monitor.global_metrics import InMemoryHeartbeatStore, ServiceMonitor
 from apps.monitor.metrics import (
     CoalescedSampler,
     DeterministicAdapter,
@@ -114,6 +115,8 @@ def test_sampler_coalesces_viewers_into_one_source_read() -> None:
                 cpu_percent=now,
                 memory_bytes=1,
                 memory_percent=None,
+                cpu_capacity_vcpus=None,
+                memory_capacity_bytes=None,
                 rx_bytes_per_second=None,
                 tx_bytes_per_second=None,
             )
@@ -131,6 +134,7 @@ def test_sampler_coalesces_viewers_into_one_source_read() -> None:
     second = sampler.sample(now=12, wall_time=102)
 
     assert adapter.calls == 2
+    assert first.deterministic is False
     assert same_generation is first
     assert second.generation == first.generation + 1
 
@@ -151,9 +155,11 @@ def test_document_serialization_never_contains_aws_or_container_identifiers() ->
     performance.record_callback(99.0, route=TASK_ARN, callback="private-container-name", now=1.0)
     performance.record_event_loop(2.1, route="/market-monitor", now=1.0)
     sampler = CoalescedSampler(adapter, performance=performance)
+    service_monitor = ServiceMonitor(sampler, InMemoryHeartbeatStore())
+    service_monitor.tick(now=100, sampled_at=2.0)
     document = Document()
 
-    build_document(document, sampler)
+    build_document(document, sampler, service_monitor)
 
     history = document.select_one({"name": "monitor-history"})
     assert history is not None

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "bokeh", extra = ["extra", "sampledata"] },
+    { name = "boto3" },
     { name = "networkx" },
     { name = "numba" },
     { name = "numpy" },
@@ -78,6 +79,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bokeh", extras = ["extra", "sampledata"], specifier = "==3.10.0" },
+    { name = "boto3", specifier = ">=1.42,<2" },
     { name = "networkx", specifier = ">=3.5,<4" },
     { name = "numba", specifier = ">=0.61,<1" },
     { name = "numpy", specifier = ">=2.0,<3" },
@@ -108,6 +110,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4e/c6/5094b4ee7b8629c2b52f987224c557b5c39213313b2e70b0302010c1186d/bokeh_sampledata-2025.0.tar.gz", hash = "sha256:6b874af5b878e70f16133695ac07e15de38642fa9fadfdf723f7d42333967af4", size = 17281129, upload-time = "2025-07-05T16:03:08.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/7d/1251c2de763d2c158cedae35857ea0c6fdd6f61dc27ad9f8630d8d174c52/bokeh_sampledata-2025.0-py3-none-any.whl", hash = "sha256:d5f7b637273c84ee89271261511f7aa9e0aeba60a21e22579fcfc1a69f878071", size = 17695013, upload-time = "2025-07-05T16:03:05.42Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.75"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/dd/b93be617dd5d1c6a3a248066030a450e62d211c0af0f49ed3a0d761383c9/boto3-1.43.75.tar.gz", hash = "sha256:86da93d3d5b46a58b03fa51b598ffa4aeaff485a3000affacf78491c105e44f0", size = 112673, upload-time = "2026-08-19T19:54:17.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/89/d0baf1269e57ac548387c11e5d9ba78d1e118ceb43f1e5e5114bdd2e8391/boto3-1.43.75-py3-none-any.whl", hash = "sha256:08a79edb68e6a0d65d305eb90188639313650e155aed015e86eef59d8475dde0", size = 140026, upload-time = "2026-08-19T19:54:15.509Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.75"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/80/5e39eda5dfb66df691d71212799a9f9d35aa9e447511604030447a00e9d6/botocore-1.43.75.tar.gz", hash = "sha256:e8ed6b0f3cd398dfb9e08d7ca3a0b964152166a317a04e89c45ec91003327ffe", size = 15973868, upload-time = "2026-08-19T19:54:12.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/46/19d3178e70f37fda251f3d9560f29654f09c6eedbe1c8b790adeee84da49/botocore-1.43.75-py3-none-any.whl", hash = "sha256:121abc8b0b529bc4e29a28d1e8b096b20f26708cabe3d5ae4b3446747712aece", size = 15667237, upload-time = "2026-08-19T19:54:08.802Z" },
 ]
 
 [[package]]
@@ -314,6 +344,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -790,6 +829,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl", hash = "sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25", size = 90216, upload-time = "2026-07-22T19:30:43.251Z" },
+]
+
+[[package]]
 name = "scikit-image"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -934,6 +985,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- expand `/monitor` from a serving-task view into a whole-service view while keeping the faster local task plots
- publish one sanitized task heartbeat every 30 seconds and share one cached service aggregate with every viewer
- combine CPU, memory, network, open Bokeh documents, page entries, callback timing, and event-loop lag across fresh tasks
- merge fixed latency histograms to calculate a sound approximate service p95 instead of averaging task p95 values
- provide a real in-memory local adapter and a clearly labeled deterministic three-task mode
- add bounded payload validation, privacy tests, deployment tests, and public data-source documentation

## Privacy and traffic boundary

The browser receives only numeric measurements, generic status text, public catalog routes, and callback names from a source-code allowlist. It does not receive AWS identifiers, resource names, publisher keys, metadata endpoints, credentials, logs, request identities, headers, referrers, or query strings.

The heartbeat loop runs once per process, not once per viewer. `/monitor` viewers read the in-process cache and never query AWS directly. The compressed maximum-size public payload is tested to remain below the 1 KiB write boundary.

## Validation

- 271 tests passed
- Ruff passed
- Pyright passed with 0 errors
- deterministic ASGI startup, `/monitor`, `/healthz`, and shutdown smoke check passed

## Rollout dependency

Blocked on [bokeh/infra#15](https://github.com/bokeh/infra/pull/15). That PR must be merged and its reviewed Terraform plan applied before this PR is merged. The deployment template references the task role and DynamoDB table created by the Infra change.

The route remains directly accessible but unlisted from the gallery and sitemap.