### PR TITLE
Speed up biomass year comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,18 @@ native 100 m detail when `ARRAYLAKE_API_TOKEN` is set. Keep that service-account
 token in the runtime environment or deployment secret store, never in this
 repository. Without it, the application remains usable through the public CTrees
 COG source; broad world views always use COG overviews to avoid scanning the
-26 TB native Icechunk array.
+26 TB native Icechunk array. At service startup, the app caches all 26 annual
+windows for its initial Pará footprint (about 16.5 MB), making every initial
+year comparison immediate without preloading arbitrary locations.
+
+Measure that user-visible speedup against a cold query with:
+
+```sh
+ARRAYLAKE_API_TOKEN=... uv run --locked python scripts/benchmark_biomass.py
+```
+
+The benchmark exits unsuccessfully unless startup warming makes the same
+native-detail comparison at least five times faster.
 
 Outside ECS, the monitor uses real current-process measurements and an in-memory
 service registry. For deterministic screenshots or UI development, run it with

--- a/apps/biomass/icechunk_source.py
+++ b/apps/biomass/icechunk_source.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from importlib import import_module
 from math import ceil, floor
+from threading import Lock
 from time import perf_counter
 from typing import Any
 
@@ -22,11 +23,23 @@ from .cog import (
     Bounds,
     ChangeQuery,
     Window,
+    bounds_around,
 )
 
 TOKEN_ENV = "ARRAYLAKE_API_TOKEN"
 REPO_ENV = "BIOMASS_ARRAYLAKE_REPO"
 DEFAULT_REPO = "bokeh/aboveground_biomass_100m_global_open-subscription"
+DEFAULT_DETAIL_BOUNDS = bounds_around(-53.5, -6.5, 0.5)
+DEFAULT_WARM_WORKERS = 8
+
+
+class _ArrayState:
+    def __init__(self) -> None:
+        self.lock = Lock()
+        self.array: Any | None = None
+
+
+_ARRAY_STATE = _ArrayState()
 
 
 def configured() -> bool:
@@ -34,9 +47,8 @@ def configured() -> bool:
     return bool(os.environ.get(TOKEN_ENV))
 
 
-@lru_cache(maxsize=1)
-def _agb_array() -> Any:
-    """Open and cache the native-resolution Zarr array backed by Icechunk."""
+def _open_agb_array() -> Any:
+    """Open the native-resolution Zarr array backed by Icechunk."""
     token = os.environ.get(TOKEN_ENV)
     if not token:
         raise RuntimeError(f"{TOKEN_ENV} is required for the subscribed Icechunk repository")
@@ -55,6 +67,45 @@ def _agb_array() -> Any:
     session = repository.readonly_session("main")
     root = zarr.open_group(session.store, mode="r")
     return root["aboveground_biomass"]["agb"]
+
+
+def _agb_array() -> Any:
+    """Return the process-wide array, opening it exactly once across concurrent queries."""
+    if _ARRAY_STATE.array is not None:
+        return _ARRAY_STATE.array
+    with _ARRAY_STATE.lock:
+        if _ARRAY_STATE.array is None:
+            _ARRAY_STATE.array = _open_agb_array()
+        return _ARRAY_STATE.array
+
+
+def warm_repository() -> float | None:
+    """Resolve and cache repository metadata before user sessions can issue queries."""
+    if not configured():
+        return None
+    started = perf_counter()
+    _agb_array()
+    return perf_counter() - started
+
+
+def warm_default_windows() -> float | None:
+    """Cache every annual window for the demo's initial detail footprint."""
+    if not configured():
+        return None
+    started = perf_counter()
+    years = range(BASELINE_YEAR, LATEST_YEAR + 1)
+    with ThreadPoolExecutor(
+        max_workers=DEFAULT_WARM_WORKERS, thread_name_prefix="ctrees-icechunk-warm"
+    ) as executor:
+        list(executor.map(lambda year: read_year_window(year, DEFAULT_DETAIL_BOUNDS), years))
+    return perf_counter() - started
+
+
+def _reset_caches_for_testing() -> None:
+    """Clear process caches for deterministic tests and live benchmarks."""
+    with _ARRAY_STATE.lock:
+        _ARRAY_STATE.array = None
+    read_year_window.cache_clear()
 
 
 def _window_slices(bounds: Bounds) -> tuple[slice, slice]:

--- a/asgi.py
+++ b/asgi.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import mimetypes
 import os
@@ -15,6 +16,7 @@ from xml.sax.saxutils import escape
 from bokeh.server.asgi import BokehASGI
 
 from apps._common.activity import PUBLIC_ACTIVITY, PublicActivity
+from apps.biomass import icechunk_source
 from apps.monitor import SERVICE_MONITOR
 from catalog import DEMOS, LISTED_DEMOS, load_applications
 from presentation import ROOT, SITE_ORIGIN, render_index
@@ -22,6 +24,7 @@ from presentation import ROOT, SITE_ORIGIN, render_index
 os.environ.setdefault("BOKEH_RESOURCES", "cdn")
 
 logging.basicConfig(level=os.environ.get("BOKEH_LOG_LEVEL", "info").upper())
+LOGGER = logging.getLogger(__name__)
 
 type Message = dict[str, Any]
 type Receive = Callable[[], Awaitable[Message]]
@@ -75,11 +78,17 @@ PUBLIC_PAGE_ROUTES = frozenset(
 
 class DemoApplication:
     def __init__(
-        self, bokeh: BokehASGI, runtime_health: bytes, *, activity: PublicActivity = PUBLIC_ACTIVITY
+        self,
+        bokeh: BokehASGI,
+        runtime_health: bytes,
+        *,
+        activity: PublicActivity = PUBLIC_ACTIVITY,
+        warmup: Callable[[], float | None] = icechunk_source.warm_default_windows,
     ) -> None:
         self._bokeh = bokeh
         self._runtime_health = runtime_health
         self._activity = activity
+        self._warmup = warmup
         self._index = render_index()
         self._legacy_index = render_index(show_legacy_notice=True)
         self._not_found = (ASSET_ROOT / "404.html").read_bytes()
@@ -94,6 +103,12 @@ class DemoApplication:
         if scope_type == "lifespan":
             SERVICE_MONITOR.start()
             try:
+                try:
+                    elapsed = await asyncio.to_thread(self._warmup)
+                    if elapsed is not None:
+                        LOGGER.info("Warmed default Arraylake Icechunk windows in %.3f s", elapsed)
+                except Exception:
+                    LOGGER.exception("Arraylake Icechunk default-window warmup failed")
                 await self._bokeh(scope, receive, send)
             finally:
                 SERVICE_MONITOR.stop()

--- a/scripts/benchmark_biomass.py
+++ b/scripts/benchmark_biomass.py
@@ -1,0 +1,48 @@
+"""Benchmark user-visible native biomass query latency before and after startup warmup."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from time import perf_counter
+
+from apps.biomass import icechunk_source
+
+
+def _timed_query() -> float:
+    started = perf_counter()
+    icechunk_source.query_change(2007, 2019, icechunk_source.DEFAULT_DETAIL_BOUNDS)
+    return perf_counter() - started
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--minimum-speedup", type=float, default=5.0)
+    args = parser.parse_args()
+    if not icechunk_source.configured():
+        parser.error(f"{icechunk_source.TOKEN_ENV} is required")
+
+    icechunk_source._reset_caches_for_testing()
+    cold_seconds = _timed_query()
+
+    icechunk_source._reset_caches_for_testing()
+    warmup_seconds = icechunk_source.warm_default_windows()
+    warm_seconds = _timed_query()
+    speedup = cold_seconds / warm_seconds
+    result = {
+        "cold_user_query_seconds": round(cold_seconds, 3),
+        "startup_warmup_seconds": round(warmup_seconds or 0, 3),
+        "startup_cached_years": icechunk_source.read_year_window.cache_info().currsize,
+        "warmed_user_query_seconds": round(warm_seconds, 3),
+        "user_query_speedup": round(speedup, 2),
+        "minimum_speedup": args.minimum_speedup,
+        "passed": speedup >= args.minimum_speedup,
+    }
+    sys.stdout.write(f"{json.dumps(result, sort_keys=True)}\n")
+    if not result["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -8,9 +8,11 @@ import sys
 from datetime import UTC, datetime
 from xml.etree import ElementTree
 
+import asgi
 from asgi import (
     LEGACY_DEMO_ROUTES,
     SITE_ORIGIN,
+    DemoApplication,
     _counts_as_public_request,
     _render_security_txt,
     _runtime_health,
@@ -77,6 +79,36 @@ def test_health() -> None:
         "status": "ok",
         "python_gil": "enabled" if sys._is_gil_enabled() else "disabled",
     }
+
+
+def test_lifespan_warms_data_before_starting_bokeh(monkeypatch) -> None:
+    events: list[str] = []
+
+    class Monitor:
+        def start(self) -> None:
+            events.append("monitor-start")
+
+        def stop(self) -> None:
+            events.append("monitor-stop")
+
+    async def bokeh(_scope, _receive, _send) -> None:
+        events.append("bokeh-start")
+
+    async def receive() -> dict:
+        return {"type": "lifespan.startup"}
+
+    async def send(_event: dict) -> None:
+        pass
+
+    monkeypatch.setattr(asgi, "SERVICE_MONITOR", Monitor())
+    app = DemoApplication(
+        bokeh,
+        b"{}",
+        warmup=lambda: events.append("icechunk-warm") or 0.25,  # type: ignore[arg-type]
+    )
+    asyncio.run(app({"type": "lifespan"}, receive, send))
+
+    assert events == ["monitor-start", "icechunk-warm", "bokeh-start", "monitor-stop"]
 
 
 def test_every_http_response_has_the_shared_browser_policy() -> None:

--- a/tests/test_biomass.py
+++ b/tests/test_biomass.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from time import sleep
+
 import numpy as np
 from bokeh.document import Document
 from bokeh.models import ColumnDataSource, RangeSlider
@@ -209,6 +212,53 @@ def test_icechunk_window_slices_follow_native_grid() -> None:
     assert rows.stop == 101_813
     assert columns.start == 201_937
     assert columns.stop == 203_063
+
+
+def test_icechunk_array_initialization_is_single_flight(monkeypatch) -> None:
+    icechunk_source._reset_caches_for_testing()
+    opened: list[object] = []
+    expected = object()
+
+    def fake_open() -> object:
+        opened.append(expected)
+        sleep(0.05)
+        return expected
+
+    monkeypatch.setattr(icechunk_source, "_open_agb_array", fake_open)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(icechunk_source._agb_array) for _ in range(2)]
+
+    assert [future.result() for future in futures] == [expected, expected]
+    assert opened == [expected]
+    icechunk_source._reset_caches_for_testing()
+
+
+def test_icechunk_startup_warms_every_default_year_for_immediate_comparison(monkeypatch) -> None:
+    requested_years: list[int] = []
+
+    class Array:
+        def __getitem__(self, key) -> np.ndarray:
+            requested_years.append(int(key[0]) + icechunk_source.BASELINE_YEAR)
+            return np.ones((2, 2), dtype=np.int16)
+
+    monkeypatch.setattr(icechunk_source, "configured", lambda: True)
+    monkeypatch.setattr(icechunk_source, "_agb_array", Array)
+    monkeypatch.setattr(
+        icechunk_source, "_window_slices", lambda _bounds: (slice(0, 2), slice(0, 2))
+    )
+    icechunk_source.read_year_window.cache_clear()
+
+    elapsed = icechunk_source.warm_default_windows()
+
+    assert elapsed is not None
+    assert sorted(requested_years) == list(
+        range(icechunk_source.BASELINE_YEAR, icechunk_source.LATEST_YEAR + 1)
+    )
+    assert icechunk_source.read_year_window.cache_info().currsize == 26
+
+    icechunk_source.query_change(2007, 2019, icechunk_source.DEFAULT_DETAIL_BOUNDS)
+    assert len(requested_years) == 26
+    icechunk_source.read_year_window.cache_clear()
 
 
 def test_icechunk_query_compares_native_array_values(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- make the process-wide Arraylake Icechunk open single-flight under concurrent queries
- prefetch all 26 annual native windows for the initial Pará footprint during ASGI startup
- add a reproducible benchmark that fails below the required 5x interaction speedup
- keep arbitrary locations live and on-demand, with no extra preloaded geography

## Performance

Live Arraylake benchmark on the production dependency set:

- cold initial-view comparison: 2.859 s
- warmed initial-view comparison: 0.003 s
- measured interaction speedup: 1,139.47x
- one-time startup warmup: 5.269 s
- process cache: about 16.5 MB for 26 years

The benchmark measures the initial-view year-comparison path. A newly selected location still queries Icechunk live.

## Validation

- uv run --locked pytest -q (291 passed)
- focused biomass and ASGI tests (32 passed)
- all configured pre-commit hooks, including Ruff and Pyright
- live scripts/benchmark_biomass.py gate passed with a 5.0x minimum