### PR TITLE
Deploy on native ARM runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   publish-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     environment: production
     steps:
       - uses: actions/checkout@v6
@@ -43,11 +43,6 @@ jobs:
       - name: Log in to Amazon ECR
         id: ecr
         uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Set up ARM emulation
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/README.md
+++ b/README.md
@@ -201,10 +201,10 @@ The `bokeh/infra` repository owns the AWS resources under
 `terraform/stacks/aws-demo`. This repository contains no Terraform.
 
 The **Publish and deploy** workflow runs for every push to `main` and may also
-be started manually. It uses GitHub OIDC to cross-build a Linux ARM64 image,
-push it to ECR under an immutable `sha-*` tag, register a new ECS task
-definition, update the `worker` service, wait for stability, and verify the
-production health endpoint.
+be started manually. It uses GitHub OIDC to build a Linux ARM64 image natively
+on GitHub's ARM64 runner, push it to ECR under an immutable `sha-*` tag,
+register a new ECS task definition, update the `worker` service, wait for
+stability, and verify the production health endpoint.
 
 Pull requests run all checks and build the container without publishing or
 deploying it. Merging to `main` is therefore the normal release action; no

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -38,7 +38,8 @@ def test_monitor_receives_sanitized_exchange_configuration() -> None:
 def test_deployment_builds_the_matching_arm64_image() -> None:
     workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text()
 
-    assert "docker/setup-qemu-action@v3" in workflow
+    assert "runs-on: ubuntu-24.04-arm" in workflow
+    assert "docker/setup-qemu-action@v3" not in workflow
     assert "docker/setup-buildx-action@v3" in workflow
     assert "docker buildx build --platform linux/arm64" in workflow
 


### PR DESCRIPTION
Use GitHub's native ARM64 runner for production image builds and remove QEMU emulation. This avoids multi-hour free-threaded dependency builds that outlive the temporary AWS credentials. Deployment tests and documentation now enforce and describe the native runner.