### PR TITLE
Report failed ECS deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,25 @@ jobs:
         run: uv run --locked python -m compileall -q asgi.py catalog.py presentation.py apps tests
 
   container:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - name: Build container
         run: docker build --tag bokeh-demo:test .
+      - name: Start container
+        run: docker run --detach --read-only --name bokeh-demo --publish 5006:5006 bokeh-demo:test
+      - name: Wait for container health
+        run: |
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:5006/healthz; then
+              exit 0
+            fi
+            sleep 2
+          done
+          exit 1
+      - name: Show container logs after failure
+        if: failure()
+        run: docker logs bokeh-demo
+      - name: Stop container
+        if: always()
+        run: docker rm --force bokeh-demo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      diagnose:
+        description: Describe the current ECS service without deploying
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: demo-bokeh-org-production
@@ -41,13 +47,16 @@ jobs:
           allowed-account-ids: "562605262404"
 
       - name: Log in to Amazon ECR
+        if: ${{ !inputs.diagnose }}
         id: ecr
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up Docker Buildx
+        if: ${{ !inputs.diagnose }}
         uses: docker/setup-buildx-action@v3
 
       - name: Build or reuse immutable image
+        if: ${{ !inputs.diagnose }}
         id: image
         env:
           ECR_REGISTRY: ${{ steps.ecr.outputs.registry }}
@@ -78,6 +87,7 @@ jobs:
           echo "\`$image\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Render ECS task definition
+        if: ${{ !inputs.diagnose }}
         id: task-definition
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
@@ -88,6 +98,7 @@ jobs:
             ARRAYLAKE_API_TOKEN=${{ secrets.ARRAYLAKE_API_TOKEN }}
 
       - name: Deploy to ECS
+        if: ${{ !inputs.diagnose }}
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: ${{ steps.task-definition.outputs.task-definition }}
@@ -98,4 +109,23 @@ jobs:
           propagate-tags: SERVICE
 
       - name: Smoke test production
+        if: ${{ !inputs.diagnose }}
         run: python scripts/smoke_production.py
+
+      - name: Diagnose ECS service
+        if: ${{ inputs.diagnose }}
+        run: |
+          aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
+            --query 'services[0].{taskDefinition:taskDefinition,runningCount:runningCount,pendingCount:pendingCount,deployments:deployments[].{id:id,status:status,taskDefinition:taskDefinition,rolloutState:rolloutState,rolloutStateReason:rolloutStateReason,runningCount:runningCount,pendingCount:pendingCount,failedTasks:failedTasks},events:events[0:20].{createdAt:createdAt,message:message}}' \
+            --output json
+
+      - name: Report ECS deployment failure
+        if: ${{ failure() && !inputs.diagnose }}
+        run: |
+          aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
+            --query 'services[0].{taskDefinition:taskDefinition,runningCount:runningCount,pendingCount:pendingCount,deployments:deployments[].{id:id,status:status,taskDefinition:taskDefinition,rolloutState:rolloutState,rolloutStateReason:rolloutStateReason,runningCount:runningCount,pendingCount:pendingCount,failedTasks:failedTasks},events:events[0:20].{createdAt:createdAt,message:message}}' \
+            --output json

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN chown -R bokeh:bokeh /app
 USER 10001:10001
 
 ENV PATH="/app/.venv/bin:$PATH" \
+    NUMBA_CACHE_DIR=/dev/shm/numba-cache \
     PYTHON_GIL=0 \
     UV_PYTHON_DOWNLOADS=never
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -64,6 +64,25 @@ def test_deployment_smoke_checks_the_catalog_and_websocket() -> None:
     assert 'urljoin(base_url, "/sitemap.xml")' in smoke
 
 
+def test_deployment_can_report_ecs_failures_without_mutating_the_service() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text()
+
+    assert "diagnose:" in workflow
+    assert "aws ecs describe-services" in workflow
+    assert "if: ${{ inputs.diagnose }}" in workflow
+    assert "if: ${{ failure() && !inputs.diagnose }}" in workflow
+    mutating_steps = (
+        "Log in to Amazon ECR",
+        "Set up Docker Buildx",
+        "Build or reuse immutable image",
+        "Render ECS task definition",
+        "Deploy to ECS",
+        "Smoke test production",
+    )
+    for name in mutating_steps:
+        assert f"- name: {name}\n        if: ${{{{ !inputs.diagnose }}}}" in workflow
+
+
 def test_deployment_injects_arraylake_token_without_committing_it() -> None:
     workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text()
     task = (ROOT / "deploy" / "ecs-task-definition.json").read_text()

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -51,6 +51,7 @@ def test_container_builds_native_free_threaded_dependencies_off_image() -> None:
     assert "apt-get install --yes --no-install-recommends build-essential" in dockerfile
     assert "COPY --from=build /opt/python /opt/python" in dockerfile
     assert "COPY --from=build /app/.venv /app/.venv" in dockerfile
+    assert "NUMBA_CACHE_DIR=/dev/shm/numba-cache" in dockerfile
 
 
 def test_arm_container_starts_with_the_production_filesystem_constraint() -> None:

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -53,6 +53,15 @@ def test_container_builds_native_free_threaded_dependencies_off_image() -> None:
     assert "COPY --from=build /app/.venv /app/.venv" in dockerfile
 
 
+def test_arm_container_starts_with_the_production_filesystem_constraint() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
+
+    assert "runs-on: ubuntu-24.04-arm" in workflow
+    assert "docker run --detach --read-only" in workflow
+    assert "curl --fail --silent http://127.0.0.1:5006/healthz" in workflow
+    assert "if: failure()\n        run: docker logs bokeh-demo" in workflow
+
+
 def test_deployment_smoke_checks_the_catalog_and_websocket() -> None:
     workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text()
     smoke = (ROOT / "scripts" / "smoke_production.py").read_text()


### PR DESCRIPTION
Add a read-only workflow-dispatch mode that reports current ECS service state and recent events without logging into ECR, building an image, rendering a task definition, updating the service, or running the production smoke test. Failed normal deployments also report the same scoped evidence. Focused tests and all repository hooks pass.