### PR TITLE
Fix image-processing control feedback

### DIFF
--- a/apps/image_lab/__init__.py
+++ b/apps/image_lab/__init__.py
@@ -231,6 +231,13 @@ def modify_document(document) -> None:
         line_color="#fffdf9",
         line_width=1.5,
     )
+    crop_request.js_on_change(
+        "data",
+        CustomJS(
+            args={"box": crop_box, "handles": crop_handles},
+            code=load_javascript(__file__, "sync_crop_box.js"),
+        ),
+    )
 
     start_crop = CustomJS(
         args={"box": crop_box, "state": crop_interaction},
@@ -279,7 +286,8 @@ def modify_document(document) -> None:
         image = np.ascontiguousarray(selection.values)
         image_filter = FILTERS[operation.value]
         started = perf_counter()
-        result = image_filter.processor(image, strength.value)
+        amount = float(cast(float, strength_request.data["value"][0]))
+        result = image_filter.processor(image, amount)
         elapsed = 1000 * (perf_counter() - started)
         height, width, _ = image.shape
         processed_source.patch({"image": [(0, rgba_view(result))]})
@@ -310,8 +318,6 @@ def modify_document(document) -> None:
     def restore_crop() -> None:
         crop["x"] = (260, 740)
         crop["y"] = (196, 676)
-        crop_box.update(**initial_crop_box)
-        crop_handles.data = dict(initial_crop_handles)
         crop_request.data = {name: [value] for name, value in initial_crop_box.items()}
 
     @performance.measure
@@ -335,7 +341,6 @@ def modify_document(document) -> None:
     @performance.measure
     def update_strength(_attr: str, _old: object, _new: object) -> None:
         if not configuring["operation"]:
-            strength.value = float(cast(float, strength_request.data["value"][0]))
             calculate()
 
     operation.on_change("value", configure_filter)

--- a/apps/image_lab/sync_crop_box.js
+++ b/apps/image_lab/sync_crop_box.js
@@ -1,0 +1,11 @@
+const left = cb_obj.data.left[0]
+const right = cb_obj.data.right[0]
+const bottom = cb_obj.data.bottom[0]
+const top = cb_obj.data.top[0]
+
+box.update({left, right, bottom, top})
+handles.data = {
+  x: [left, right, right, left],
+  y: [bottom, bottom, top, top],
+}
+handles.change.emit()

--- a/tests/test_image_lab.py
+++ b/tests/test_image_lab.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 from bokeh.document import Document
+from bokeh.events import ButtonClick
 from bokeh.models import BoxAnnotation, Button, ColumnDataSource, Div, PanTool, Select, Slider
 
 from catalog import load_applications
@@ -56,6 +57,10 @@ def test_hubble_filters_and_editable_crop_update_the_result() -> None:
     assert not strength.syncable
     assert "change:value" in strength.js_property_callbacks
     assert "change:value_throttled" in strength.js_property_callbacks
+    assert set(crop_request.js_property_callbacks) == {"change:data"}
+    crop_sync = crop_request.js_property_callbacks["change:data"][0]
+    assert "box.update" in crop_sync.code
+    assert "handles.change.emit()" in crop_sync.code
     results = []
     for option in operation.options:
         operation.value = option
@@ -68,9 +73,17 @@ def test_hubble_filters_and_editable_crop_update_the_result() -> None:
     operation.value = "Sobel edges"
     edges = processed.data["image"][0].copy()
     strength_request.data = {"value": [3.0]}
+    assert strength.value == 2.2
     assert not np.array_equal(edges, processed.data["image"][0])
 
-    crop_box.update(left=0, right=0.48, bottom=1 - 480 / 872, top=1)
     crop_request.data = {"left": [0], "right": [0.48], "bottom": [1 - 480 / 872], "top": [1]}
     assert "x=0:480" in report.text
     assert "y=0:480" in report.text
+
+    reset_crop._trigger_event(ButtonClick(reset_crop))
+    assert crop_request.data == {
+        "left": [260 / 1000],
+        "right": [740 / 1000],
+        "bottom": [1 - 676 / 872],
+        "top": [1 - 196 / 872],
+    }


### PR DESCRIPTION
## Summary

- keep the browser-owned crop rectangle and handles synchronized when resetting the crop
- process throttled slider requests without echoing delayed values back into the active slider
- add regression coverage for crop reset synchronization and stale slider feedback

## Testing

- uv run --locked pytest (314 passed)
- uv run --locked pre-commit run --all-files
- local browser verification for crop reset and the Gamma, Sobel, Unsharp mask, and Color saturation sliders
- browser console checked with no warnings or errors

Closes #43